### PR TITLE
fix(release): switch to OIDC trusted publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,9 +41,7 @@ jobs:
         run: node dist/cli.js scan . --json
 
       - name: Publish to npm
-        run: pnpm publish --no-git-checks --access public
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: npm publish --access public
 
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v2

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -245,7 +245,7 @@ Language support involves several layers:
 
 ## Releases
 
-Releases are automated. When a maintainer creates a GitHub Release (or pushes a `v*` tag), CI builds and publishes to npm. See `.github/workflows/release.yml`.
+Releases are automated. When a maintainer creates a GitHub Release (or pushes a `v*` tag), CI builds and publishes to npm using OIDC trusted publishing -- no long-lived tokens required. See `.github/workflows/release.yml`.
 
 Version bumps follow [semver](https://semver.org/):
 


### PR DESCRIPTION
## Summary

Switch npm publishing from long-lived `NPM_TOKEN` to OIDC trusted publishing. No tokens to rotate or leak.

## Changes

- Remove `NODE_AUTH_TOKEN` / `NPM_TOKEN` from release workflow
- Switch `pnpm publish` to `npm publish` (npm CLI auto-detects OIDC)
- `id-token: write` permission was already set

## Setup required on npmjs.com

Before this works, configure a trusted publisher on the package settings page:

1. Go to https://www.npmjs.com/package/slop/access (after first publish)
2. Trusted Publisher section > GitHub Actions
3. Organization: `heavykenny`
4. Repository: `slop`
5. Workflow filename: `release.yml`