### PR TITLE
chore(ci): auto-sync main → develop after every squash merge

### DIFF
--- a/.github/workflows/sync-develop.yml
+++ b/.github/workflows/sync-develop.yml
@@ -1,0 +1,61 @@
+name: Sync main → develop
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch: {}
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: develop
+
+      - name: Configure git identity
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+      - name: Fetch main
+        run: git fetch origin main
+
+      - name: Fast-forward if possible, otherwise merge
+        id: merge
+        run: |
+          if git merge-base --is-ancestor origin/main HEAD; then
+            echo "develop already contains main — nothing to do"
+            echo "needs_sync=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          echo "needs_sync=true" >> "$GITHUB_OUTPUT"
+          if git merge --no-ff origin/main -m "chore: sync main → develop (auto)"; then
+            echo "clean=true" >> "$GITHUB_OUTPUT"
+          else
+            git merge --abort
+            echo "clean=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Push clean merge
+        if: steps.merge.outputs.needs_sync == 'true' && steps.merge.outputs.clean == 'true'
+        run: git push origin develop
+
+      - name: Open sync PR on conflict
+        if: steps.merge.outputs.needs_sync == 'true' && steps.merge.outputs.clean == 'false'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh pr list --base develop --head main --json number --jq '.[].number' | xargs -I{} echo "existing sync PR: #{}" || true
+          if ! gh pr list --base develop --head main --state open --json number --jq '.[].number' | grep -q .; then
+            gh pr create \
+              --base develop \
+              --head main \
+              --title "chore: sync main → develop (manual resolution needed)" \
+              --body "Auto-merge from the main→develop sync workflow hit conflicts. Resolve locally and push." || true
+          fi


### PR DESCRIPTION
Prevents the repeat conflict pattern we hit on #35, #37, #41.

## The problem

PRs into main get squash-merged (per settings), so one commit lands on main representing N commits from develop. Develop keeps its individual commits. Git's merge algorithm can't tell "those N = that one squash" and the next develop → main PR flags conflicts on every file the squash touched.

Seen three times now: #35 (v0.5.1), #37 (v0.6.0), #41 (v0.6.1) all needed manual `merge origin/main → develop` + `checkout --ours` on ~12 files before the PR diff was clean.

## The fix

On every push to main, a GitHub Action:
1. Checks out develop
2. Fetches main
3. If main is already an ancestor of develop — no-op (e.g. right after #41 merges, this case).
4. Otherwise attempts a clean merge commit on develop and pushes.
5. If the merge conflicts (which would be unusual post-this-workflow — only happens if develop has diverged in a way that genuinely conflicts), opens a sync PR so the divergence is visible rather than silently accumulating.

Uses the default `GITHUB_TOKEN` (no PAT needed) with `contents: write` + `pull-requests: write`.

## Test plan

- [x] Workflow YAML parses (commited under `.github/workflows/sync-develop.yml`).
- [ ] After merge, next push to main triggers the workflow. Verify: should either no-op (if develop already has main — current state after #41) or cleanly merge and push.
- [ ] `workflow_dispatch` trigger works for manual invocation.

## After this lands

No more manual "merge main back into develop" step after a release. Sync is automatic.