### PR TITLE
release: v0.6.2 — suppress knip/binaries on .github/workflows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.6.2 (2026-04-22)
+
+Single-finding patch: the knip-backed `Unlisted binary` rule was firing on `.github/workflows/**` for runner-provided tools like `gh`, `aws`, `docker`, and `jq`, which can never be declared in `package.json`.
+
+### Fixed
+
+- **`knip/binaries` no longer flags CI workflow files.** `src/engines/code-quality/knip.ts` now routes every issue through `shouldIncludeIssue(issueType, filePath)`; the predicate drops `binaries` diagnostics whose file path lives under `.github/workflows/`. Backslashes are normalised so Windows paths behave the same. The rule stays active everywhere else, so an npm script invoking an undeclared tool is still a real signal.
+
+### Tests
+
+- 3 new unit tests in `tests/knip-deps.test.ts` covering the predicate: workflow binaries dropped, non-workflow binaries kept, other issue types unaffected in workflow files. Total suite: 617 (614 + 3).
+
 ## 0.6.1 (2026-04-20)
 
 A follow-up round after 0.6.0 went live: hook UX gaps surfaced on first contact, README was still on 0.5.x, and adding deterministic duplicate-detection caught real issues in aislop's own source.

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ Sample output:
  [!]  Code Quality: done (2 warnings, 812ms)
  [!]  AI Slop: done (4 warnings, 455ms)
  [ok] Security: done (0 issues, 1.3s)
- aislop 0.6.1  ·  the quality gate for agentic coding
+ aislop 0.6.2  ·  the quality gate for agentic coding
 
  scan  ·  my-app  ·  typescript  ·  142 files
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "aislop",
-	"version": "0.6.1",
+	"version": "0.6.2",
 	"description": "Stop AI slop from shipping. A unified code quality CLI that catches the lazy patterns AI coding tools leave behind.",
 	"type": "module",
 	"bin": {

--- a/src/engines/code-quality/knip.ts
+++ b/src/engines/code-quality/knip.ts
@@ -55,6 +55,13 @@ const getIssueItems = (fileIssue: KnipFileIssue, issueType: string): KnipIssueIt
 	return Array.isArray(items) ? items : [];
 };
 
+// Runner-provided binaries (gh, aws, docker) can't be listed in package.json.
+export const shouldIncludeIssue = (issueType: string, filePath: string): boolean => {
+	if (issueType !== "binaries") return true;
+	const normalized = filePath.replace(/\\/g, "/");
+	return !normalized.includes(".github/workflows/");
+};
+
 const DEPENDENCY_HELP: Record<string, string> = {
 	dependencies:
 		"This package is listed in package.json but not imported anywhere. Remove it with `npm uninstall` or `npx aislop fix`.",
@@ -73,6 +80,7 @@ const collectIssues = (
 	knipCwd: string,
 ): Diagnostic[] => {
 	const diagnostics: Diagnostic[] = [];
+	if (!shouldIncludeIssue(issueType, fileIssue.file)) return diagnostics;
 	const issues = getIssueItems(fileIssue, issueType);
 	const isDepType = isDependencyType(issueType);
 	const category = isDepType ? "Dependencies" : "Dead Code";

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,1 +1,1 @@
-export const APP_VERSION = process.env.VERSION ?? "0.6.1";
+export const APP_VERSION = process.env.VERSION ?? "0.6.2";

--- a/tests/knip-deps.test.ts
+++ b/tests/knip-deps.test.ts
@@ -69,3 +69,30 @@ describe("knip dependency diagnostic shape", () => {
 		expect(mod.fixKnipUnusedExports).toBeUndefined();
 	});
 });
+
+describe("shouldIncludeIssue", () => {
+	const loadPredicate = async () => {
+		const mod = await import("../src/engines/code-quality/knip.js");
+		return mod.shouldIncludeIssue;
+	};
+
+	it("drops binaries diagnostics for .github/workflows files", async () => {
+		// Workflow YAML invokes runner-provided binaries (gh, aws, docker, jq)
+		// that can never appear in package.json — pure false positive.
+		const shouldIncludeIssue = await loadPredicate();
+		expect(shouldIncludeIssue("binaries", ".github/workflows/sync-develop.yml")).toBe(false);
+		expect(shouldIncludeIssue("binaries", ".github\\workflows\\ci.yml")).toBe(false);
+	});
+
+	it("keeps binaries diagnostics for non-workflow files", async () => {
+		const shouldIncludeIssue = await loadPredicate();
+		expect(shouldIncludeIssue("binaries", "scripts/release.sh")).toBe(true);
+		expect(shouldIncludeIssue("binaries", "package.json")).toBe(true);
+	});
+
+	it("does not suppress other issue types in workflow files", async () => {
+		const shouldIncludeIssue = await loadPredicate();
+		expect(shouldIncludeIssue("dependencies", ".github/workflows/sync.yml")).toBe(true);
+		expect(shouldIncludeIssue("unlisted", ".github/workflows/sync.yml")).toBe(true);
+	});
+});


### PR DESCRIPTION
## Summary

- knip's `Unlisted binary` rule was a guaranteed false positive on `.github/workflows/**` — workflow YAML invokes runner-provided binaries (`gh`, `aws`, `docker`, `jq`, …) that cannot be declared in `package.json`. Self-scan surfaced it on `sync-develop.yml` and scored the repo 97 / 100.
- Route every issue through `shouldIncludeIssue(issueType, filePath)` in `src/engines/code-quality/knip.ts`; drop `knip/binaries` diagnostics whose path lives under `.github/workflows/` (backslash-normalised for Windows). Rule stays active everywhere else, so an npm script invoking an undeclared tool is still flagged.
- Version → `0.6.2`, CHANGELOG + README banner updated.

## Test plan

- [x] `pnpm build` clean.
- [x] `pnpm vitest run tests/knip-deps.test.ts` — 7 / 7 pass (3 new: workflow binaries dropped, non-workflow binaries kept, other issue types unaffected).
- [x] Self-scan: `node dist/cli.js scan .` now reports 100 / 100 Healthy (was 97 / 100 with the false positive).
- [x] `node dist/cli.js --version` prints `0.6.2`.