### PR TITLE
feat(config): add `extends:` to .aislop/config.yml (Plan 5.B4)

### DIFF
--- a/src/config/extends.ts
+++ b/src/config/extends.ts
@@ -1,0 +1,72 @@
+import fs from "node:fs";
+import path from "node:path";
+import YAML from "yaml";
+
+const MAX_DEPTH = 5;
+
+const isPlainObject = (v: unknown): v is Record<string, unknown> =>
+	typeof v === "object" && v !== null && !Array.isArray(v);
+
+// child wins on scalar conflict, plain objects deep-merge, arrays replace.
+const deepMerge = (...sources: Record<string, unknown>[]): Record<string, unknown> => {
+	const result: Record<string, unknown> = {};
+	for (const source of sources) {
+		for (const key of Object.keys(source)) {
+			const a = result[key];
+			const b = source[key];
+			result[key] = isPlainObject(a) && isPlainObject(b) ? deepMerge(a, b) : b;
+		}
+	}
+	return result;
+};
+
+const resolveExtendsRef = (ref: string, fromDir: string): string => {
+	if (ref.startsWith("http://") || ref.startsWith("https://")) {
+		throw new Error(`URL-based extends not yet supported: ${ref}`);
+	}
+	if (ref.startsWith("./") || ref.startsWith("../") || path.isAbsolute(ref)) {
+		return path.resolve(fromDir, ref);
+	}
+	throw new Error(`Package-name extends not yet supported: ${ref} (use a relative path for now)`);
+};
+
+const normalizeExtends = (raw: unknown): string[] => {
+	if (raw === undefined || raw === null) return [];
+	if (typeof raw === "string") return [raw];
+	if (Array.isArray(raw) && raw.every((s) => typeof s === "string")) {
+		return raw;
+	}
+	throw new Error("`extends` must be a string or array of strings");
+};
+
+export const loadConfigChain = (
+	configPath: string,
+	visited: ReadonlySet<string> = new Set(),
+	depth = 0,
+): Record<string, unknown> => {
+	if (depth > MAX_DEPTH) {
+		throw new Error(`extends depth exceeded ${MAX_DEPTH} (cycle or runaway chain): ${configPath}`);
+	}
+	const absPath = path.resolve(configPath);
+	if (visited.has(absPath)) {
+		throw new Error(`circular extends detected: ${absPath}`);
+	}
+	if (!fs.existsSync(absPath)) {
+		throw new Error(`extends target not found: ${absPath}`);
+	}
+	const nextVisited = new Set(visited);
+	nextVisited.add(absPath);
+
+	const raw = fs.readFileSync(absPath, "utf-8");
+	const parsed = (YAML.parse(raw) ?? {}) as Record<string, unknown>;
+
+	const refs = normalizeExtends(parsed.extends);
+	const fromDir = path.dirname(absPath);
+	const parents = refs.map((ref) => {
+		const parentPath = resolveExtendsRef(ref, fromDir);
+		return loadConfigChain(parentPath, nextVisited, depth + 1);
+	});
+
+	const { extends: _drop, ...own } = parsed;
+	return deepMerge(...parents, own);
+};

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -1,7 +1,7 @@
 import fs from "node:fs";
 import path from "node:path";
-import YAML from "yaml";
 import { DEFAULT_CONFIG } from "./defaults.js";
+import { loadConfigChain } from "./extends.js";
 import { type AislopConfig, parseConfig } from "./schema.js";
 
 export const CONFIG_DIR = ".aislop";
@@ -30,9 +30,8 @@ export const loadConfig = (directory: string): AislopConfig => {
 	if (!fs.existsSync(configPath)) return DEFAULT_CONFIG;
 
 	try {
-		const raw = fs.readFileSync(configPath, "utf-8");
-		const parsed = YAML.parse(raw);
-		return parseConfig(parsed);
+		const merged = loadConfigChain(configPath);
+		return parseConfig(merged);
 	} catch (error) {
 		const msg = error instanceof Error ? error.message : String(error);
 		process.stderr.write(

--- a/tests/config-extends.test.ts
+++ b/tests/config-extends.test.ts
@@ -1,0 +1,123 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { loadConfigChain } from "../src/config/extends.js";
+
+let tmp: string;
+
+beforeEach(() => {
+	tmp = fs.mkdtempSync(path.join(os.tmpdir(), "aislop-extends-"));
+});
+
+afterEach(() => {
+	fs.rmSync(tmp, { recursive: true, force: true });
+});
+
+const write = (rel: string, body: string): string => {
+	const full = path.join(tmp, rel);
+	fs.mkdirSync(path.dirname(full), { recursive: true });
+	fs.writeFileSync(full, body);
+	return full;
+};
+
+describe("loadConfigChain", () => {
+	it("returns an empty object for an empty file", () => {
+		const p = write("empty.yml", "");
+		expect(loadConfigChain(p)).toEqual({});
+	});
+
+	it("returns the file content when no extends present", () => {
+		const p = write("plain.yml", "engines:\n  format: false\nquality:\n  maxFunctionLoc: 50");
+		const merged = loadConfigChain(p);
+		expect(merged).toEqual({ engines: { format: false }, quality: { maxFunctionLoc: 50 } });
+	});
+
+	it("merges a single relative parent (child wins on scalar)", () => {
+		write("parent.yml", "engines:\n  format: false\nquality:\n  maxFunctionLoc: 200");
+		const child = write(
+			"child.yml",
+			"extends: ./parent.yml\nquality:\n  maxFunctionLoc: 100",
+		);
+		const merged = loadConfigChain(child);
+		expect(merged).toEqual({
+			engines: { format: false },
+			quality: { maxFunctionLoc: 100 },
+		});
+	});
+
+	it("strips the extends key from the merged result", () => {
+		write("p.yml", "engines:\n  format: false");
+		const c = write("c.yml", "extends: ./p.yml\nquality:\n  maxFunctionLoc: 90");
+		const merged = loadConfigChain(c);
+		expect(merged.extends).toBeUndefined();
+	});
+
+	it("handles array of parents merged left-to-right (last wins)", () => {
+		write("a.yml", "quality:\n  maxFunctionLoc: 100\n  maxFileLoc: 100");
+		write("b.yml", "quality:\n  maxFunctionLoc: 200");
+		const c = write(
+			"c.yml",
+			"extends:\n  - ./a.yml\n  - ./b.yml\nquality:\n  maxFileLoc: 999",
+		);
+		const merged = loadConfigChain(c);
+		expect(merged.quality).toEqual({ maxFunctionLoc: 200, maxFileLoc: 999 });
+	});
+
+	it("deep-merges nested objects but replaces arrays", () => {
+		write(
+			"p.yml",
+			"engines:\n  format: false\n  lint: true\nexclude:\n  - .git\n  - node_modules",
+		);
+		const c = write("c.yml", "extends: ./p.yml\nengines:\n  format: true\nexclude:\n  - dist");
+		const merged = loadConfigChain(c) as {
+			engines: Record<string, boolean>;
+			exclude: string[];
+		};
+		expect(merged.engines).toEqual({ format: true, lint: true });
+		expect(merged.exclude).toEqual(["dist"]);
+	});
+
+	it("detects circular references", () => {
+		const a = write("a.yml", "extends: ./b.yml\nx: 1");
+		write("b.yml", "extends: ./a.yml\ny: 2");
+		expect(() => loadConfigChain(a)).toThrow(/circular extends/);
+	});
+
+	it("rejects missing parent file with a helpful error", () => {
+		const c = write("c.yml", "extends: ./missing.yml");
+		expect(() => loadConfigChain(c)).toThrow(/extends target not found/);
+	});
+
+	it("enforces max depth 5", () => {
+		for (let i = 0; i < 7; i++) {
+			const next = i === 6 ? "" : `extends: ./step-${i + 1}.yml\n`;
+			write(`step-${i}.yml`, next);
+		}
+		expect(() => loadConfigChain(path.join(tmp, "step-0.yml"))).toThrow(
+			/depth exceeded/,
+		);
+	});
+
+	it("rejects URL extends with a clear message", () => {
+		const c = write("c.yml", "extends: https://example.com/config.yml");
+		expect(() => loadConfigChain(c)).toThrow(/URL-based extends not yet supported/);
+	});
+
+	it("rejects bare package-name extends with a clear message", () => {
+		const c = write("c.yml", "extends: \"@scanaislop/pack-nextjs\"");
+		expect(() => loadConfigChain(c)).toThrow(/Package-name extends not yet supported/);
+	});
+
+	it("rejects a malformed extends value", () => {
+		const c = write("c.yml", "extends: 123");
+		expect(() => loadConfigChain(c)).toThrow(/string or array of strings/);
+	});
+
+	it("absolute path target resolves and merges", () => {
+		const parentAbs = write("p.yml", "quality:\n  maxFileLoc: 1234");
+		const c = write("c.yml", `extends: ${parentAbs}\nquality:\n  maxFunctionLoc: 50`);
+		const merged = loadConfigChain(c) as { quality: Record<string, number> };
+		expect(merged.quality).toEqual({ maxFileLoc: 1234, maxFunctionLoc: 50 });
+	});
+});


### PR DESCRIPTION
## What

Plan 5.B4 — `extends:` in the CLI config schema. Layered configs. A child config names parent files; the chain is merged left-to-right; child wins on scalar conflicts, objects deep-merge, arrays replace.

## Why now

Unblocks **Plan 5.B3 stack packs** (so `aislop init --pack nextjs` can ship as a one-line `extends:` to a pinned base, instead of dumping the full config into every repo) and a future rule-pack marketplace.

## Surface

```yaml
# .aislop/config.yml
extends:
  - ./shared/aislop-base.yml      # array form, merged left-to-right
  - ./team-overrides.yml
quality:
  maxFileLoc: 600                  # child wins
```

`extends` is string or array of strings; stripped from the parsed result so it doesn't leak into the validated `AislopConfig` type.

## Semantics

| | |
|---|---|
| relative paths (`./`, `../`, absolute) | ✅ supported |
| URL extends (`https://…`) | ❌ throws clear "not yet supported" error |
| package-name extends (`@scope/pack-x`) | ❌ throws clear "not yet supported" error |
| max depth | 5 |
| circular | detected, throws |
| missing parent file | throws with resolved absolute path |
| empty file as parent | merges as `{}` |
| scalar conflict | child wins |
| object conflict | deep merge |
| array conflict | replace (child wins entirely) |

## Verification

- `pnpm typecheck` clean
- `pnpm test` 630 / 630 (was 617; +13 new cases in `tests/config-extends.test.ts`)
- `aislop scan` 92 / 100 (the 2 remaining warnings are pre-existing on main: postcss vuln + unused file unrelated to this change)

## Files

- `src/config/extends.ts` (new) — `loadConfigChain` walker + `deepMerge` + `resolveExtendsRef`
- `src/config/index.ts` — `loadConfig` now calls `loadConfigChain` instead of single-file YAML.parse
- `tests/config-extends.test.ts` (new) — 13 cases covering every semantic above

## Backwards compatibility

Existing configs without `extends` are untouched — `loadConfigChain` collapses to a single-file read. Default behaviour identical to before this PR.