### PR TITLE
docs(badges): surface public badge URL in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -318,7 +318,7 @@ The CLI is MIT-licensed and always will be. [Learn more about the platform →](
 Show your aislop score on a README. Free for any project that opts in on [scanaislop.com](https://scanaislop.com).
 
 ```markdown
-![aislop](https://badges.scanaislop.com/score/<owner>/<repo>.svg)
+[![aislop](https://badges.scanaislop.com/score/<owner>/<repo>.svg)](https://scanaislop.com)
 ```
 
 Shields-compatible SVG, edge-cached on Cloudflare. Colour-coded: green ≥ 85, amber 70-84, red < 70, grey if no scans yet.

--- a/README.md
+++ b/README.md
@@ -313,6 +313,16 @@ ci:
 
 The CLI is MIT-licensed and always will be. [Learn more about the platform →](https://scanaislop.com)
 
+## Public score badge
+
+Show your aislop score on a README. Free for any project that opts in on [scanaislop.com](https://scanaislop.com).
+
+```markdown
+![aislop](https://badges.scanaislop.com/score/<owner>/<repo>.svg)
+```
+
+Shields-compatible SVG, edge-cached on Cloudflare. Colour-coded: green ≥ 85, amber 70-84, red < 70, grey if no scans yet.
+
 ## Contributing
 
 See [CONTRIBUTING.md](CONTRIBUTING.md) for development setup and how to add new rules. AI coding assistants can find project context in [AGENTS.md](AGENTS.md).


### PR DESCRIPTION
## Summary
- Adds a "Public score badge" section to the main README showing the `https://badges.scanaislop.com/score/<owner>/<repo>.svg` URL and a markdown embed snippet.
- The Worker is live, so OSS users can now opt in via the platform and publish the badge.

## Test plan
- [x] Renders cleanly in GitHub markdown.
- [ ] Markdown snippet works once the project is opted in via `PATCH /v1/orgs/:slug/projects/:repo { publicBadgeEnabled: true }`.