### PR TITLE
release: v0.7.0 — extends, public badge in header, postcss floor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,28 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.7.0 (2026-05-01)
+
+Two user-facing additions plus a security floor on a transitive dependency.
+
+### Added
+
+- **`extends:` in `.aislop/config.yml` (#45).** Inherit a parent config and override only the keys you need. Accepts a single relative path or an array; later entries win on conflict. Nested objects deep-merge key-by-key, arrays replace wholesale. Circular references and chains deeper than 5 are rejected at load time. Useful for org-wide baselines: one strict parent in the monorepo root, per-package overrides for `ci.failBelow` or specific weights. Documented in [`docs/configuration.md`](docs/configuration.md#extending-a-shared-config).
+- **Public score badge in the README header (#46).** Shields-compatible SVG served from `badges.scanaislop.com`, edge-cached. Drop one line into any README that opts in:
+  ```markdown
+  [![aislop](https://badges.scanaislop.com/score/<owner>/<repo>.svg)](https://scanaislop.com/<owner>/<repo>)
+  ```
+  Colour bands: green ≥ 85, amber 70–84, red < 70, grey if no scans yet. The CLI's own README now wears the badge alongside `npm version`, `CI`, and `License`.
+
+### Security
+
+- **Floor on `postcss` transitive (#49).** Added a `pnpm.overrides` entry pinning `postcss` ≥ 8.5.10 so `aislop scan`'s own `security/vulnerable-dependency` rule no longer fires on this repo. No top-level dep used postcss directly; the override is the right tool over a runtime dep that doesn't exist. Resolved version is `8.5.13`.
+
+### Internal
+
+- 8 commits land on develop including 3 auto-syncs from the `main → develop` workflow added in 0.6.2.
+- A draft PR (#48) parks an unwired TypeScript-as-lint engine — the implementation is solid but the registry, schema, config gate, and tests are deliberately not in this release.
+
 ## 0.6.2 (2026-04-22)
 
 Single-finding patch: the knip-backed `Unlisted binary` rule was firing on `.github/workflows/**` for runner-provided tools like `gh`, `aws`, `docker`, and `jq`, which can never be declared in `package.json`.

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 [![npm version](https://img.shields.io/npm/v/aislop.svg)](https://www.npmjs.com/package/aislop)
 [![npm downloads](https://img.shields.io/npm/dm/aislop.svg)](https://www.npmjs.com/package/aislop)
 [![CI](https://github.com/scanaislop/aislop/actions/workflows/ci.yml/badge.svg)](https://github.com/scanaislop/aislop/actions/workflows/ci.yml)
+[![aislop score](https://badges.scanaislop.com/score/scanaislop/aislop.svg)](https://scanaislop.com/scanaislop/aislop)
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](https://opensource.org/licenses/MIT)
 [![Node >= 20](https://img.shields.io/badge/node-%3E%3D20-brightgreen.svg)](https://nodejs.org)
 
@@ -34,7 +35,7 @@ npx aislop fix
 # CI mode (JSON output + quality gate)
 npx aislop ci
 
-# wire aislop into your agent so it runs on every edit (new in 0.6.0)
+# wire aislop into your agent so it runs on every edit
 npx aislop hook install --claude
 ```
 
@@ -46,7 +47,7 @@ Sample output:
  [!]  Code Quality: done (2 warnings, 812ms)
  [!]  AI Slop: done (4 warnings, 455ms)
  [ok] Security: done (0 issues, 1.3s)
- aislop 0.6.2  ·  the quality gate for agentic coding
+ aislop 0.7.0  ·  the quality gate for agentic coding
 
  scan  ·  my-app  ·  typescript  ·  142 files
 
@@ -78,7 +79,7 @@ AI coding tools generate code that compiles and passes tests but ships with patt
 
 - **One score, one gate**: a 0-100 number you can enforce in CI with `aislop ci`. Weighted so sloppy patterns (dead code, `as any`, swallowed errors) hit harder than style noise.
 - **Auto-fix first, agent second**: `aislop fix` clears what's mechanically safe (formatters, unused imports, trivial comments, dead patterns). For the rest, one flag hands off to Claude Code, Codex, Cursor, Gemini, Windsurf, Amp, Aider, Goose, and 7 more, with full diagnostic context pre-filled.
-- **Wire it into your agent (new in 0.6.0)**: `aislop hook install` plugs aislop into Claude Code, Cursor, Gemini CLI (runtime), plus Codex, Windsurf, Cline, Kilo Code, Antigravity, and Copilot (rules-only). The agent gets score + findings on the turn it wrote the code, not after.
+- **Wire it into your agent**: `aislop hook install` plugs aislop into Claude Code, Cursor, Gemini CLI (runtime), plus Codex, Windsurf, Cline, Kilo Code, Antigravity, and Copilot (rules-only). The agent gets score + findings on the turn it wrote the code, not after.
 - **Deterministic**: regex, AST, and standard tooling. No LLMs, no API keys, no network dependency. Same repo in, same score out.
 - **Zero-config start**: `npx aislop scan` works on any repo. Add `.aislop/config.yml` when you want to tune thresholds or enable the architecture engine.
 - **Works across stacks**: TypeScript, JavaScript, Python, Go, Rust, Ruby, PHP, Expo / React Native.
@@ -153,6 +154,18 @@ aislop scan --exclude "src/generated" --exclude "**/*.spec.*"
 ```
 
 CLI flags beat config; config beats defaults.
+
+**Extend a shared config.** A project config can extend a parent and override specific keys. Useful for org-wide baselines: ship one strict config, let each repo soften or tighten as needed.
+
+```yaml
+# .aislop/config.yml
+extends: ../../.aislop/base.yml   # relative path to a parent config
+
+ci:
+  failBelow: 80                   # override just this key, inherit the rest
+```
+
+`extends:` accepts a single path or an array of paths. Later entries win. Deep-merged: nested objects (`scoring.weights`, `engines`) are merged key-by-key; arrays are replaced. Circular references and depths beyond 5 are rejected with a clear error.
 
 ### Fix issues automatically
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -87,6 +87,33 @@ scoring:
   smoothing: 20        # increase to reduce penalty spikes on larger repos
 ```
 
+## Extending a shared config
+
+`extends:` lets a project inherit a parent config and override only the keys it cares about. Useful for org-wide baselines.
+
+```yaml
+# packages/payments/.aislop/config.yml
+extends: ../../.aislop/base.yml
+
+ci:
+  failBelow: 80         # override one key, inherit everything else from the parent
+```
+
+Multiple parents are supported via an array; later entries win on conflict:
+
+```yaml
+extends:
+  - ../../.aislop/base.yml
+  - ./local-overrides.yml
+```
+
+**Resolution rules**
+
+- Paths are relative to the config file declaring `extends:`. Absolute paths are accepted; package or URL forms are not yet supported and will fail with a clear error.
+- Nested objects (`engines`, `scoring.weights`, `quality`) are deep-merged key-by-key. The child's keys win on conflict.
+- Arrays (e.g. `exclude:`) are replaced wholesale, not concatenated. Append in the child if you want to extend rather than overwrite.
+- Cycles and chains deeper than 5 levels are rejected at load time, not silently ignored.
+
 ## Architecture rules
 
 Create `.aislop/rules.yml` to define custom import and path rules. Enable the architecture engine in your config:

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "aislop",
-	"version": "0.6.2",
+	"version": "0.7.0",
 	"description": "Stop AI slop from shipping. A unified code quality CLI that catches the lazy patterns AI coding tools leave behind.",
 	"type": "module",
 	"bin": {

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,1 +1,1 @@
-export const APP_VERSION = process.env.VERSION ?? "0.6.2";
+export const APP_VERSION = process.env.VERSION ?? "0.7.0";


### PR DESCRIPTION
## What's in v0.7.0

Two user-facing additions and a security floor on a transitive dep, plus a README polish pass.

### Added
- **`extends:` in `.aislop/config.yml` (#45).** Inherit a parent config and override only the keys you need. Deep-merges nested objects, replaces arrays, rejects cycles and chains > 5.
- **Public score badge in the README header (#46).** The CLI's own README now wears the badge alongside `npm version`, `CI`, and `License`.

### Security
- **`postcss` floor via `pnpm.overrides` (#49).** Resolves `8.5.13`. Closes the `security/vulnerable-dependency` finding aislop's own scan reports on this repo.

### README polish
- Score badge added to the header badge strip.
- Sample-output banner: `0.6.2` → `0.7.0`.
- Stale `(new in 0.6.0)` qualifiers dropped from the Quick start and the "Why aislop" bullet — they read as outdated two versions later.
- New `extends:` subsection under Usage > Scan with a worked example.
- Full resolution rules added to `docs/configuration.md` (relative-path requirement, deep-merge for objects, replace-for-arrays, cycle + depth-5 rejection).

### Internal
- `package.json` and `src/version.ts` bumped to `0.7.0`.
- Draft PR #48 parks the unwired typecheck engine for a future minor.

## Test plan
- [x] `pnpm build` clean — 296 KB total.
- [x] `pnpm test` → 630 / 630 passing.
- [x] `node dist/cli.js scan --json` reports `cliVersion: "0.7.0"`, score 100, 0 diagnostics.
- [ ] After merge → "promote develop → main" PR (the existing release flow).

## PRs included in this release
- #45 — feat(config): `extends:`
- #46 — docs(badges): public badge link in CLI README
- #49 — chore(deps): postcss override (still open at the time of writing this PR; if it merges before this one, this is a no-op section)