### PR TITLE
feat: aislop badge — print README markdown for the public score badge

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,5 +1,6 @@
 import { Command } from "commander";
 import { registerHookCommand } from "./cli/hook-command.js";
+import { badgeCommand } from "./commands/badge.js";
 import { ciCommand } from "./commands/ci.js";
 import { doctorCommand } from "./commands/doctor.js";
 import { fixCommand } from "./commands/fix.js";
@@ -209,6 +210,31 @@ program
 	.description("List all available rules")
 	.action(async (directory = ".") => {
 		await rulesCommand(directory);
+	});
+
+program
+	.command("badge [directory]")
+	.description("Print the public score badge URL + README markdown for this repo")
+	.option("--owner <owner>", "GitHub owner (auto-detected from git remote if omitted)")
+	.option("--repo <repo>", "GitHub repo name (auto-detected from git remote if omitted)")
+	.option("--json", "emit machine-readable JSON instead of the rendered output")
+	.action(async (directory = ".", _flags, command) => {
+		const flags = command.optsWithGlobals() as {
+			owner?: string;
+			repo?: string;
+			json?: boolean;
+		};
+		try {
+			await badgeCommand({
+				directory,
+				owner: flags.owner,
+				repo: flags.repo,
+				json: Boolean(flags.json),
+			});
+		} catch (err: any) {
+			process.stderr.write(`${err?.message ?? "Failed to print badge"}\n`);
+			process.exit(1);
+		}
 	});
 
 registerHookCommand(program);

--- a/src/commands/badge.ts
+++ b/src/commands/badge.ts
@@ -4,26 +4,29 @@ import path from "node:path";
 const GITHUB_REMOTE_RE =
 	/^(?:git@github\.com:|https:\/\/(?:[^@]+@)?github\.com\/)([^/]+)\/([^/.\s]+?)(?:\.git)?\s*$/;
 
-export interface BadgeOptions {
+interface BadgeOptions {
 	owner?: string;
 	repo?: string;
 	directory?: string;
 	json?: boolean;
 }
 
-export interface BadgeRenderInput {
+interface BadgeRenderInput {
 	owner: string;
 	repo: string;
 	svgUrl: string;
 	pageUrl: string;
 }
 
-export const renderBadgeOutput = ({
-	owner,
-	repo,
-	svgUrl,
-	pageUrl,
-}: BadgeRenderInput): string => {
+interface BadgeResult {
+	owner: string;
+	repo: string;
+	svgUrl: string;
+	pageUrl: string;
+	output: string;
+}
+
+export const renderBadgeOutput = ({ owner, repo, svgUrl, pageUrl }: BadgeRenderInput): string => {
 	const slug = `${owner}/${repo}`;
 	const markdown = `[![aislop](${svgUrl})](${pageUrl})`;
 	return [
@@ -40,9 +43,7 @@ export const renderBadgeOutput = ({
 	].join("\n");
 };
 
-const detectGithubSlugFromGit = (
-	directory: string,
-): { owner: string; repo: string } | null => {
+const detectGithubSlugFromGit = (directory: string): { owner: string; repo: string } | null => {
 	let raw: string;
 	try {
 		raw = execSync("git remote get-url origin", {
@@ -61,17 +62,7 @@ const detectGithubSlugFromGit = (
 	return { owner, repo };
 };
 
-export interface BadgeResult {
-	owner: string;
-	repo: string;
-	svgUrl: string;
-	pageUrl: string;
-	output: string;
-}
-
-export const badgeCommand = async (
-	options: BadgeOptions = {},
-): Promise<BadgeResult> => {
+export const badgeCommand = async (options: BadgeOptions = {}): Promise<BadgeResult> => {
 	let owner = options.owner?.trim();
 	let repo = options.repo?.trim();
 

--- a/src/commands/badge.ts
+++ b/src/commands/badge.ts
@@ -1,0 +1,100 @@
+import { execSync } from "node:child_process";
+import path from "node:path";
+
+const GITHUB_REMOTE_RE =
+	/^(?:git@github\.com:|https:\/\/(?:[^@]+@)?github\.com\/)([^/]+)\/([^/.\s]+?)(?:\.git)?\s*$/;
+
+export interface BadgeOptions {
+	owner?: string;
+	repo?: string;
+	directory?: string;
+	json?: boolean;
+}
+
+export interface BadgeRenderInput {
+	owner: string;
+	repo: string;
+	svgUrl: string;
+	pageUrl: string;
+}
+
+export const renderBadgeOutput = ({
+	owner,
+	repo,
+	svgUrl,
+	pageUrl,
+}: BadgeRenderInput): string => {
+	const slug = `${owner}/${repo}`;
+	const markdown = `[![aislop](${svgUrl})](${pageUrl})`;
+	return [
+		``,
+		`  Repository:  ${slug}`,
+		`  Badge URL:   ${svgUrl}`,
+		``,
+		`  Markdown:`,
+		``,
+		`    ${markdown}`,
+		``,
+		`  Drop the line above into your README. The badge auto-updates after every public scan.`,
+		``,
+	].join("\n");
+};
+
+const detectGithubSlugFromGit = (
+	directory: string,
+): { owner: string; repo: string } | null => {
+	let raw: string;
+	try {
+		raw = execSync("git remote get-url origin", {
+			cwd: path.resolve(directory),
+			encoding: "utf-8",
+			stdio: ["ignore", "pipe", "ignore"],
+		});
+	} catch {
+		return null;
+	}
+	const match = raw.trim().match(GITHUB_REMOTE_RE);
+	if (!match) return null;
+	const owner = match[1];
+	const repo = match[2];
+	if (!owner || !repo) return null;
+	return { owner, repo };
+};
+
+export interface BadgeResult {
+	owner: string;
+	repo: string;
+	svgUrl: string;
+	pageUrl: string;
+	output: string;
+}
+
+export const badgeCommand = async (
+	options: BadgeOptions = {},
+): Promise<BadgeResult> => {
+	let owner = options.owner?.trim();
+	let repo = options.repo?.trim();
+
+	if (!owner || !repo) {
+		const detected = detectGithubSlugFromGit(options.directory ?? ".");
+		if (!detected) {
+			throw new Error(
+				"Could not detect a GitHub remote. Run from a repo with `git remote get-url origin` set, or pass --owner and --repo.",
+			);
+		}
+		owner ??= detected.owner;
+		repo ??= detected.repo;
+	}
+
+	const svgUrl = `https://badges.scanaislop.com/score/${owner}/${repo}.svg`;
+	const pageUrl = `https://scanaislop.com/${owner}/${repo}`;
+	const output = renderBadgeOutput({ owner, repo, svgUrl, pageUrl });
+
+	if (options.json) {
+		process.stdout.write(JSON.stringify({ owner, repo, svgUrl, pageUrl }) + "\n");
+	} else {
+		process.stdout.write(output);
+	}
+
+	return { owner, repo, svgUrl, pageUrl, output };
+};

--- a/tests/commands/badge.test.ts
+++ b/tests/commands/badge.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from "vitest";
+import { renderBadgeOutput } from "../../src/commands/badge.js";
+
+describe("renderBadgeOutput", () => {
+	it("emits the markdown snippet pointing at badges.scanaislop.com and the project page", () => {
+		const out = renderBadgeOutput({
+			owner: "scanaislop",
+			repo: "aislop",
+			svgUrl: "https://badges.scanaislop.com/score/scanaislop/aislop.svg",
+			pageUrl: "https://scanaislop.com/scanaislop/aislop",
+		});
+
+		expect(out).toContain("scanaislop/aislop");
+		expect(out).toContain(
+			"https://badges.scanaislop.com/score/scanaislop/aislop.svg",
+		);
+		expect(out).toContain(
+			"[![aislop](https://badges.scanaislop.com/score/scanaislop/aislop.svg)](https://scanaislop.com/scanaislop/aislop)",
+		);
+	});
+
+	it("renders consistently for any owner/repo pair", () => {
+		const out = renderBadgeOutput({
+			owner: "vercel",
+			repo: "next.js",
+			svgUrl: "https://badges.scanaislop.com/score/vercel/next.js.svg",
+			pageUrl: "https://scanaislop.com/vercel/next.js",
+		});
+
+		expect(out).toContain("vercel/next.js");
+		expect(out).toContain(
+			"[![aislop](https://badges.scanaislop.com/score/vercel/next.js.svg)](https://scanaislop.com/vercel/next.js)",
+		);
+	});
+});


### PR DESCRIPTION
## Summary

Closes the missing piece of Plan 5 (adoption engine). The badges worker has been live at \`badges.scanaislop.com\` since v0.5.x, but until now there was no CLI command to grab the embed snippet — users had to hand-write the markdown.

\`\`\`
$ aislop badge

  Repository:  scanaislop/aislop
  Badge URL:   https://badges.scanaislop.com/score/scanaislop/aislop.svg

  Markdown:

    [![aislop](https://badges.scanaislop.com/score/scanaislop/aislop.svg)](https://scanaislop.com/scanaislop/aislop)
\`\`\`

## Modes

| Invocation | Behavior |
|---|---|
| \`aislop badge\` | Auto-detect owner/repo from \`git remote get-url origin\` |
| \`aislop badge --owner X --repo Y\` | Explicit override |
| \`aislop badge --json\` | Machine-readable JSON: \`{owner, repo, svgUrl, pageUrl}\` |

Git-remote regex accepts ssh + https forms. Non-GitHub remotes return a clear error.

## Verification

- [x] \`pnpm typecheck\` — clean
- [x] Full test suite — 632/632 pass (2 new in \`tests/commands/badge.test.ts\`)
- [x] Manual smoke: all three modes confirmed