### PR TITLE
fix(ci): also trigger CI on develop pushes and PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,9 @@ name: CI
 
 on:
   push:
-    branches: [main]
+    branches: [main, develop]
   pull_request:
-    branches: [main]
+    branches: [main, develop]
 
 permissions:
   contents: read


### PR DESCRIPTION
## What does this PR do?

Unblocks PRs targeting \`develop\`. Today \`.github/workflows/ci.yml\` only triggers on \`branches: [main]\`, so any PR against develop sits at \`mergeStateStatus: BLOCKED\` forever — the **Protect develop** ruleset requires \`Build, test, quality gate (22)\` and \`(24)\`, but those checks never run.

\`\`\`diff
 on:
   push:
-    branches: [main]
+    branches: [main, develop]
   pull_request:
-    branches: [main]
+    branches: [main, develop]
\`\`\`

## Why this is being opened against main, not develop

Bootstrap. Same workflow, same trap — opening it against develop would block on the very checks this PR is fixing. Once this lands on main, the auto-sync workflow brings it to develop, and every future change to develop flows through normal PR review.

## Type of change

- [x] Bug fix
- [ ] New rule
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [x] CI / tooling

## Checklist

- [x] \`pnpm typecheck\` passes — N/A, no code changes
- [x] \`pnpm test\` passes — N/A, no code changes
- [x] \`pnpm build && node dist/cli.js scan .\` scores Healthy — N/A, no code changes
- [x] New rules have positive AND negative test cases — N/A
- [x] New rules are registered in \`src/commands/rules.ts\` — N/A
- [x] Self-detection patterns use string concatenation — N/A

## Related

- Surfaces #57 (docs PR currently stuck on this).
- Will allow re-triggering #57 after merge by pushing an empty commit to its branch.