### PR TITLE
fix(ci): sync workflow pushes refresh branch, no direct write to develop

### DIFF
--- a/.github/workflows/sync-develop.yml
+++ b/.github/workflows/sync-develop.yml
@@ -7,7 +7,6 @@ on:
 
 permissions:
   contents: write
-  pull-requests: write
 
 jobs:
   sync:
@@ -26,36 +25,28 @@ jobs:
       - name: Fetch main
         run: git fetch origin main
 
-      - name: Fast-forward if possible, otherwise merge
-        id: merge
+      - name: Decide what to do
+        id: plan
         run: |
           if git merge-base --is-ancestor origin/main HEAD; then
-            echo "develop already contains main — nothing to do"
             echo "needs_sync=false" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-          echo "needs_sync=true" >> "$GITHUB_OUTPUT"
-          if git merge --no-ff origin/main -m "chore: sync main → develop (auto)"; then
-            echo "clean=true" >> "$GITHUB_OUTPUT"
           else
-            git merge --abort
-            echo "clean=false" >> "$GITHUB_OUTPUT"
+            echo "needs_sync=true" >> "$GITHUB_OUTPUT"
           fi
 
-      - name: Push clean merge
-        if: steps.merge.outputs.needs_sync == 'true' && steps.merge.outputs.clean == 'true'
-        run: git push origin develop
-
-      - name: Open sync PR on conflict
-        if: steps.merge.outputs.needs_sync == 'true' && steps.merge.outputs.clean == 'false'
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Push refresh branch
+        if: steps.plan.outputs.needs_sync == 'true'
         run: |
-          gh pr list --base develop --head main --json number --jq '.[].number' | xargs -I{} echo "existing sync PR: #{}" || true
-          if ! gh pr list --base develop --head main --state open --json number --jq '.[].number' | grep -q .; then
-            gh pr create \
-              --base develop \
-              --head main \
-              --title "chore: sync main → develop (manual resolution needed)" \
-              --body "Auto-merge from the main→develop sync workflow hit conflicts. Resolve locally and push." || true
-          fi
+          git checkout -B bot/sync-from-main origin/main
+          git push --force origin bot/sync-from-main
+          {
+            echo "### main moved ahead of develop"
+            echo ""
+            echo "Pushed \`bot/sync-from-main\` (= origin/main). Open a PR to bring develop up to date:"
+            echo ""
+            echo "https://github.com/${{ github.repository }}/compare/develop...bot/sync-from-main?expand=1"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: No-op summary
+        if: steps.plan.outputs.needs_sync == 'false'
+        run: echo "develop already contains main — nothing to do." >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
## What does this PR do?

The \`Sync main → develop\` workflow has been failing on every \`main\` push since develop got protected:

\`\`\`
remote: error: GH013: Repository rule violations found for refs/heads/develop.
- Changes must be made through a pull request.
- 2 of 2 required status checks have not succeeded.
- This branch must not contain merge commits.
\`\`\`

\`GITHUB_TOKEN\` can't bypass the **Protect develop** ruleset. Same trap the contributors workflow hit; same fix.

## Fix

Drop the direct push. Instead, force-push a snapshot of \`origin/main\` to a side branch \`bot/sync-from-main\` and write a one-click compare URL to the run summary.

\`\`\`yaml
- Push refresh branch (was: Push clean merge)
  run: |
    git checkout -B bot/sync-from-main origin/main
    git push --force origin bot/sync-from-main
    {
      echo "### main moved ahead of develop"
      echo "..."
      echo "https://github.com/\${{ github.repository }}/compare/develop...bot/sync-from-main?expand=1"
    } >> "\$GITHUB_STEP_SUMMARY"
\`\`\`

After every push to main, the maintainer sees the workflow summary in the Actions tab, clicks the compare URL, and merges the resulting PR. Develop catches up.

## Side benefits

- **No \`pull-requests: write\` permission needed** since the workflow doesn't try to create a PR. \`contents: write\` to push the side branch is enough.
- **No "Allow GitHub Actions to create PRs" toggle** required — that's the other repo setting we already worked around for contributors.
- **The resulting PR is a clean fast-forward** of develop to main (no merge commits to violate linear-history). If develop has commits main doesn't (rare), the PR shows a conflict and a human resolves it.

## Type of change

- [x] Bug fix
- [ ] New rule
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [x] CI / tooling

## Test plan
- [x] YAML lints clean.
- [ ] After merge: any push to main triggers the workflow. If develop is up to date, run summary reads "nothing to do." If main moved ahead, run summary links to a compare page that opens a PR with one click.