### PR TITLE
refactor(ci): split build & test from quality gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ permissions:
 
 jobs:
   check:
-    name: Build, test, quality gate
+    name: Build & test
     runs-on: ubuntu-latest
 
     strategy:
@@ -41,8 +41,25 @@ jobs:
       - name: Test
         run: pnpm vitest run
 
-      # Self-gate on one matrix version only — we just need to know the PR's
-      # build passes aislop ci against itself; no need to run it on every Node.
-      - name: Quality gate (aislop ci)
-        if: matrix.node-version == 22
+  quality-gate:
+    name: Quality gate
+    needs: check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: pnpm/action-setup@v5
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Build
+        run: pnpm build
+
+      - name: aislop ci
         run: node dist/cli.js ci .


### PR DESCRIPTION
## What does this PR do?

Splits the misleading single-job CI into two:

| Old | New |
|---|---|
| \`Build, test, quality gate (22)\` | \`Build & test (22)\` |
| \`Build, test, quality gate (24)\` | \`Build & test (24)\` |
| (the same job, gated to Node 22) | \`Quality gate\` (separate job, depends on \`check\`) |

Three checks total, each honest about what it does. The matrix verifies Node compat (build + test on 22 and 24); the quality gate runs \`aislop ci\` once on Node 22 after the matrix passes.

## Why
The old single job was named \`Build, test, quality gate\` but only the Node 22 leg actually ran \`aislop ci\`. The Node 24 leg was just a build/test compat check. Both shipped under the same misleading name.

## Bootstrap dance

The **Protect main** and **Protect develop** rulesets currently require the OLD check names. After this PR's CI runs, the OLD names won't be emitted anymore (the jobs were renamed) and the NEW names will. So this PR is **BLOCKED** until the rulesets are updated.

Order of operations once you're ready to merge:

1. Confirm there are no other PRs in flight that depend on the old check names. (Today: #59 and #60 — those still emit the old names because their HEAD has the old workflow. Merge them first.)
2. Tell me to flip both rulesets to the new check names. One API call per ruleset.
3. GitHub re-evaluates this PR's mergeability — should clear immediately since CI will already have emitted the new names.
4. Merge this PR. Auto-sync brings it to develop next time main moves; or include in a develop → main promotion PR.

I have the ruleset patch JSON ready to fire when you say go.

## Type of change

- [ ] Bug fix
- [ ] New rule
- [ ] New feature
- [x] Refactor (no behavior change, just clearer reporting)
- [ ] Documentation
- [x] CI / tooling

## Diff

```
 .github/workflows/ci.yml | 27 ++++++++++++++++++++++-----
 1 file changed, 22 insertions(+), 5 deletions(-)
```

## Test plan

- [x] Workflow YAML lints clean.
- [ ] After ruleset update + merge: a future PR shows three checks (`Build & test (22)`, `Build & test (24)`, `Quality gate`) instead of two duplicate-named ones.