### PR TITLE
fix(ci): sync workflow opens auto-merging PR

### DIFF
--- a/.github/workflows/sync-develop.yml
+++ b/.github/workflows/sync-develop.yml
@@ -55,7 +55,7 @@ jobs:
           else
             num=$existing
           fi
-          gh pr merge "$num" --squash --auto
+          gh pr merge "$num" --squash --auto --delete-branch
 
       - name: No-op summary
         if: steps.plan.outputs.needs_sync == 'false'

--- a/.github/workflows/sync-develop.yml
+++ b/.github/workflows/sync-develop.yml
@@ -7,6 +7,7 @@ on:
 
 permissions:
   contents: write
+  pull-requests: write
 
 jobs:
   sync:
@@ -22,30 +23,39 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
 
-      - name: Fetch main
-        run: git fetch origin main
-
       - name: Decide what to do
         id: plan
         run: |
+          git fetch origin main
           if git merge-base --is-ancestor origin/main HEAD; then
             echo "needs_sync=false" >> "$GITHUB_OUTPUT"
           else
             echo "needs_sync=true" >> "$GITHUB_OUTPUT"
           fi
 
-      - name: Push refresh branch
+      - name: Refresh sync branch
         if: steps.plan.outputs.needs_sync == 'true'
         run: |
           git checkout -B bot/sync-from-main origin/main
           git push --force origin bot/sync-from-main
-          {
-            echo "### main moved ahead of develop"
-            echo ""
-            echo "Pushed \`bot/sync-from-main\` (= origin/main). Open a PR to bring develop up to date:"
-            echo ""
-            echo "https://github.com/${{ github.repository }}/compare/develop...bot/sync-from-main?expand=1"
-          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Open or update PR with auto-merge
+        if: steps.plan.outputs.needs_sync == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          existing=$(gh pr list --base develop --head bot/sync-from-main --state open --json number --jq '.[0].number // empty')
+          if [ -z "$existing" ]; then
+            num=$(gh pr create \
+              --base develop \
+              --head bot/sync-from-main \
+              --title "chore: sync main → develop" \
+              --body "Auto-opened by \`.github/workflows/sync-develop.yml\`. Brings develop up to main. Auto-merge enabled (squash) — merges itself once CI passes." \
+              --label automated | grep -oE '[0-9]+$')
+          else
+            num=$existing
+          fi
+          gh pr merge "$num" --squash --auto
 
       - name: No-op summary
         if: steps.plan.outputs.needs_sync == 'false'


### PR DESCRIPTION
## What does this PR do?

Replaces the side-branch / manual-click flow with a proper auto-merging PR. The org-level "Allow GitHub Actions to create and approve pull requests" toggle is now on (and \`allow_auto_merge\` is enabled at the repo level), so the bot can open a sync PR and let GitHub merge it once CI passes.

## Flow after this lands

```
push to main
  → sync workflow runs
  → force-pushes bot/sync-from-main = main's tip
  → opens (or updates) a PR: develop ← bot/sync-from-main
  → enables auto-merge (squash)
  → CI runs the three required checks against the merged result
  → CI passes → GitHub auto-merges → develop is up to date
  → CI fails → PR sits open with red checks for you to investigate
```

No clicks. CI is enforced. Develop's protection (PR + linear history + status checks) is untouched.

## Why squash, not merge or rebase

The Protect develop ruleset requires linear history. Merge commits are blocked. Squash collapses the sync into a single commit with a clean title.

## Type of change

- [x] Bug fix
- [ ] New rule
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [x] CI / tooling

## Test plan
- [x] YAML lints clean.
- [ ] After merge: any push to main triggers the workflow. The first run opens a PR; subsequent runs update its branch and re-enable auto-merge.