### PR TITLE
fix(ci): drop --label automated from sync PR create

### DIFF
--- a/.github/workflows/sync-develop.yml
+++ b/.github/workflows/sync-develop.yml
@@ -51,7 +51,7 @@ jobs:
               --head bot/sync-from-main \
               --title "chore: sync main → develop" \
               --body "Auto-opened by \`.github/workflows/sync-develop.yml\`. Brings develop up to main. Auto-merge enabled (squash) — merges itself once CI passes." \
-              --label automated | grep -oE '[0-9]+$')
+              | grep -oE '[0-9]+$')
           else
             num=$existing
           fi


### PR DESCRIPTION
## What does this PR do?

The just-shipped sync workflow failed on first run with:

\`\`\`
could not add label: 'automated' not found
\`\`\`

\`gh pr create --label automated\` requires the label to already exist in the repo. It doesn't. Drop the flag — the PR title (\`chore: sync main → develop\`) and the body already make the bot origin obvious. No label needed.

## Type of change

- [x] Bug fix
- [ ] CI / tooling

## Test plan

- [ ] After merge: next push to main runs the sync workflow without erroring on the label step. The PR opens and auto-merge arms.