### PR TITLE
fix(ci): sync workflow uses read-tree instead of replaying main's tip

### DIFF
--- a/.github/workflows/sync-develop.yml
+++ b/.github/workflows/sync-develop.yml
@@ -28,16 +28,24 @@ jobs:
         run: |
           git fetch origin main
           if git merge-base --is-ancestor origin/main HEAD; then
+            echo "develop already contains main — nothing to do"
+            echo "needs_sync=false" >> "$GITHUB_OUTPUT"
+          elif git diff --quiet origin/main HEAD; then
+            echo "main and develop have identical trees — only commit graph differs, skip"
             echo "needs_sync=false" >> "$GITHUB_OUTPUT"
           else
             echo "needs_sync=true" >> "$GITHUB_OUTPUT"
           fi
 
-      - name: Refresh sync branch
+      - name: Build sync commit (parent = develop, tree = main)
         if: steps.plan.outputs.needs_sync == 'true'
         run: |
-          git checkout -B bot/sync-from-main origin/main
-          git push --force origin bot/sync-from-main
+          # Don't replay main's commits onto develop — that conflicts when
+          # both branches squashed the same content under different SHAs.
+          # Capture the diff as a single commit on top of develop instead.
+          git read-tree --reset -u origin/main
+          git commit -m "chore: sync main → develop"
+          git push --force origin HEAD:refs/heads/bot/sync-from-main
 
       - name: Open or update PR with auto-merge
         if: steps.plan.outputs.needs_sync == 'true'


### PR DESCRIPTION
## Summary

Fixes the sync workflow to use `git read-tree` instead of replaying main's history. Prevents squash-history conflicts when both branches squashed identical content under different SHAs.

## Problem

The previous approach (`git checkout -B bot/sync-from-main origin/main`) made the sync branch equal to main's tip, which conflicts when both branches squashed the same content differently.

## Solution

- Uses `git read-tree --reset -u` to update the index/working tree to match main's tree
- Creates a single commit with parent = develop, tree = main
- No history replay, no 3-way merge, no conflicts
- Adds tree-diff check to skip syncs when only commit graph differs