### PR TITLE
fix(ci): dispatch CI on sync PR to bypass GHA anti-loop guard

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,12 @@ on:
     branches: [main, develop]
   pull_request:
     branches: [main, develop]
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: "Ref to run CI against"
+        required: false
+        default: ""
 
 permissions:
   contents: read

--- a/.github/workflows/sync-develop.yml
+++ b/.github/workflows/sync-develop.yml
@@ -64,6 +64,11 @@ jobs:
             num=$existing
           fi
           gh pr merge "$num" --squash --auto --delete-branch
+          # GITHUB_TOKEN-driven PRs don't fire downstream workflows (GitHub's
+          # anti-loop guard), so the required CI checks never run and the PR
+          # sits BLOCKED. Dispatch CI explicitly against the sync branch so
+          # the checks the develop ruleset demands actually appear.
+          gh workflow run ci.yml --ref bot/sync-from-main
 
       - name: No-op summary
         if: steps.plan.outputs.needs_sync == 'false'


### PR DESCRIPTION
## Summary

Adds `workflow_dispatch` trigger to CI and updates the sync workflow to explicitly dispatch CI on sync PRs.

## Problem

Sync PRs showed zero status checks because GitHub doesn't run workflows on events triggered by `GITHUB_TOKEN`. The anti-loop guard prevents automatic triggers, but also blocks CI from running.

## Solution

- Added `workflow_dispatch` input to `ci.yml` (allowed under `GITHUB_TOKEN`)
- Sync workflow now dispatches CI explicitly after opening the PR
- Dispatched runs report checks against the sync branch, satisfying the required checks for auto-merge