### PR TITLE
fix(ci): add actions:write so sync workflow can dispatch CI

### DIFF
--- a/.github/workflows/sync-develop.yml
+++ b/.github/workflows/sync-develop.yml
@@ -8,6 +8,7 @@ on:
 permissions:
   contents: write
   pull-requests: write
+  actions: write
 
 jobs:
   sync:


### PR DESCRIPTION
## Summary

Adds `actions: write` permission to the sync workflow so it can dispatch CI runs on the sync branch.

## Problem

The sync workflow tried to dispatch `ci.yml` but failed with HTTP 403 because `GITHUB_TOKEN` lacked the `actions: write` permission.

## Solution

Added `actions: write` to the workflow's permissions block.