### PR TITLE
feat(scoring): per-engine cap, file-aware smoothing, fixable discount

### DIFF
--- a/src/scoring/index.ts
+++ b/src/scoring/index.ts
@@ -7,14 +7,8 @@ export interface ScoreResult {
 
 const PERFECT_SCORE = 100;
 
-// One engine going wild (e.g. pnpm audit finding 50 vulnerable deps) should not
-// be able to drag the whole score to single digits on its own. Cap how much
-// deduction each engine contributes after weighting + fixable discount.
 const PER_ENGINE_DEDUCTION_CAP = 25;
 
-// Fixable issues are one click away from being resolved. Count them at half
-// weight so a repo full of mechanical-but-autofixable findings doesn't score
-// the same as one with the same number of architectural problems.
 const FIXABLE_DISCOUNT = 0.5;
 
 const getEffectiveFileCount = (diagnostics: Diagnostic[], sourceFileCount?: number): number => {
@@ -42,8 +36,7 @@ export const calculateScore = (
 	const byEngine = new Map<string, number>();
 	for (const d of diagnostics) {
 		const engineWeight = weights[d.engine] ?? 1.0;
-		const severityPenalty =
-			d.severity === "error" ? 3 : d.severity === "warning" ? 1 : 0.25;
+		const severityPenalty = d.severity === "error" ? 3 : d.severity === "warning" ? 1 : 0.25;
 		const fixableMultiplier = d.fixable ? FIXABLE_DISCOUNT : 1;
 		const contribution = severityPenalty * engineWeight * fixableMultiplier;
 		byEngine.set(d.engine, (byEngine.get(d.engine) ?? 0) + contribution);
@@ -58,9 +51,7 @@ export const calculateScore = (
 	// Smoothing scales with repo size so a 10k-file mature repo gets proportional
 	// headroom instead of saturating density to 1 like a 50-file slop pile.
 	const smoothingConstant =
-		typeof smoothing === "number"
-			? smoothing
-			: Math.max(10, effectiveFileCount * 0.3);
+		typeof smoothing === "number" ? smoothing : Math.max(10, effectiveFileCount * 0.3);
 	const issueDensity = Math.min(1, diagnostics.length / (effectiveFileCount + smoothingConstant));
 	const scaledDeductions = deductions * Math.sqrt(issueDensity);
 

--- a/src/scoring/index.ts
+++ b/src/scoring/index.ts
@@ -7,6 +7,16 @@ export interface ScoreResult {
 
 const PERFECT_SCORE = 100;
 
+// One engine going wild (e.g. pnpm audit finding 50 vulnerable deps) should not
+// be able to drag the whole score to single digits on its own. Cap how much
+// deduction each engine contributes after weighting + fixable discount.
+const PER_ENGINE_DEDUCTION_CAP = 25;
+
+// Fixable issues are one click away from being resolved. Count them at half
+// weight so a repo full of mechanical-but-autofixable findings doesn't score
+// the same as one with the same number of architectural problems.
+const FIXABLE_DISCOUNT = 0.5;
+
 const getEffectiveFileCount = (diagnostics: Diagnostic[], sourceFileCount?: number): number => {
 	if (typeof sourceFileCount === "number" && sourceFileCount > 0) {
 		return sourceFileCount;
@@ -28,16 +38,29 @@ export const calculateScore = (
 		return { score: PERFECT_SCORE, label: "Healthy" };
 	}
 
-	let deductions = 0;
-
+	// Group raw weighted contributions by engine so we can apply a per-engine cap.
+	const byEngine = new Map<string, number>();
 	for (const d of diagnostics) {
 		const engineWeight = weights[d.engine] ?? 1.0;
-		const severityPenalty = d.severity === "error" ? 3 : d.severity === "warning" ? 1 : 0.25;
-		deductions += severityPenalty * engineWeight;
+		const severityPenalty =
+			d.severity === "error" ? 3 : d.severity === "warning" ? 1 : 0.25;
+		const fixableMultiplier = d.fixable ? FIXABLE_DISCOUNT : 1;
+		const contribution = severityPenalty * engineWeight * fixableMultiplier;
+		byEngine.set(d.engine, (byEngine.get(d.engine) ?? 0) + contribution);
+	}
+
+	let deductions = 0;
+	for (const engineTotal of byEngine.values()) {
+		deductions += Math.min(engineTotal, PER_ENGINE_DEDUCTION_CAP);
 	}
 
 	const effectiveFileCount = getEffectiveFileCount(diagnostics, sourceFileCount);
-	const smoothingConstant = typeof smoothing === "number" ? smoothing : 10;
+	// Smoothing scales with repo size so a 10k-file mature repo gets proportional
+	// headroom instead of saturating density to 1 like a 50-file slop pile.
+	const smoothingConstant =
+		typeof smoothing === "number"
+			? smoothing
+			: Math.max(10, effectiveFileCount * 0.3);
 	const issueDensity = Math.min(1, diagnostics.length / (effectiveFileCount + smoothingConstant));
 	const scaledDeductions = deductions * Math.sqrt(issueDensity);
 

--- a/tests/scoring-comprehensive.test.ts
+++ b/tests/scoring-comprehensive.test.ts
@@ -213,14 +213,14 @@ describe("multiple issues of same severity", () => {
 		const diagnostics = Array(5).fill(makeDiagnostic({ engine: "security", severity: "error" }));
 		const result = calculateScore(diagnostics, defaultWeights, defaultThresholds);
 
-		expect(result.score).toMatchInlineSnapshot(`36`);
+		expect(result.score).toMatchInlineSnapshot(`40`);
 	});
 
 	it("snapshot: 10 security errors", () => {
 		const diagnostics = Array(10).fill(makeDiagnostic({ engine: "security", severity: "error" }));
 		const result = calculateScore(diagnostics, defaultWeights, defaultThresholds);
 
-		expect(result.score).toMatchInlineSnapshot(`20`);
+		expect(result.score).toMatchInlineSnapshot(`33`);
 	});
 
 	it("diminishing returns: overall trend is sublinear", () => {


### PR DESCRIPTION
## Summary

Calibrates the score formula to produce more actionable signals on issue-heavy repos. Previously, real-world repos with thousands of issues scored 0-13/100, which was technically accurate but not useful.

## Changes

- **Per-engine deduction cap (25)** — one engine can't single-handedly tank the score
- **File-count-aware smoothing** — large repos get proportional headroom (defaults to `max(10, fileCount * 0.3)`)
- **Fixable discount (0.5×)** — auto-fixable issues count at half weight

## Results

Clean repos preserved (100/100 stays 100/100). Issue-heavy repos lifted from 0-13 to 13-24 range. Mid-range repos (e.g., 90/100) largely unchanged.