### PR TITLE
fix: warn when dependency audit tools are missing

### DIFF
--- a/src/engines/security/audit.ts
+++ b/src/engines/security/audit.ts
@@ -62,7 +62,21 @@ const runNpmAudit = async (rootDir: string, timeout: number): Promise<Diagnostic
 		});
 		return parseJsAudit(result.stdout, "npm audit");
 	} catch {
-		return [];
+		// npm not available — warn about skipped audit
+		return [
+			{
+				filePath: "package.json",
+				engine: "security",
+				rule: "security/dependency-audit-skipped",
+				severity: "warning",
+				message: "Dependency audit skipped: npm not found",
+				help: "Ensure npm is installed to enable dependency vulnerability scanning",
+				line: 0,
+				column: 0,
+				category: "Security",
+				fixable: false,
+			},
+		];
 	}
 };
 
@@ -91,7 +105,22 @@ const runPnpmAuditWithFallback = async (
 		if (canFallbackToNpm) {
 			return runNpmAudit(rootDir, timeout);
 		}
-		return [];
+		// pnpm not available and no npm fallback — warn about skipped audit
+		return [
+			{
+				filePath: "pnpm-lock.yaml",
+				engine: "security",
+				rule: "security/dependency-audit-skipped",
+				severity: "warning",
+				message:
+					"Dependency audit skipped: pnpm not found and no package-lock.json fallback available",
+				help: "Install pnpm or generate package-lock.json to enable dependency vulnerability scanning",
+				line: 0,
+				column: 0,
+				category: "Security",
+				fixable: false,
+			},
+		];
 	}
 };
 


### PR DESCRIPTION
## Summary

Fixes silent failures in dependency audits. When npm or pnpm are missing, audit functions now emit warning diagnostics instead of returning empty results.

## Problem

When `aislop ci` runs in environments without pnpm or npm (e.g., GitHub Actions without explicit setup), audits fail silently and return no diagnostics. This causes false-positive 100/100 scores when vulnerabilities exist.

## Solution

Audit functions now emit warnings when tools are missing:
- "Dependency audit skipped: npm not found"
- "Dependency audit skipped: pnpm not found and no package-lock.json fallback available"

These warnings lower the score (~94/100 instead of false 100/100) and alert developers to misconfigured environments.