### PR TITLE
chore: dogfood aislop PR checks

### DIFF
--- a/.github/workflows/aislop.yml
+++ b/.github/workflows/aislop.yml
@@ -23,6 +23,12 @@ jobs:
           node-version: 22
           cache: pnpm
 
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Build local CLI
+        run: pnpm build
+
       - run: npx aislop scan
 
   quality-gate:

--- a/.github/workflows/aislop.yml
+++ b/.github/workflows/aislop.yml
@@ -1,0 +1,41 @@
+name: aislop
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  scan-smoke:
+    name: Scan smoke
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: pnpm/action-setup@v5
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - run: npx aislop scan
+
+  quality-gate:
+    name: Quality gate
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: pnpm/action-setup@v5
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - run: npx aislop@latest ci .


### PR DESCRIPTION
Adds a dedicated aislop workflow with two public dogfood checks: `npx aislop scan` for smoke coverage and `npx aislop@latest ci .` for the quality gate. Leaves the existing built-CLI self-test in CI intact.