### PR TITLE
chore: clarify aislop PR checks

### DIFF
--- a/.github/workflows/aislop.yml
+++ b/.github/workflows/aislop.yml
@@ -34,7 +34,7 @@ jobs:
         run: pnpm build
 
       - name: Test
-        run: pnpm vitest run
+        run: pnpm test
 
   scan-smoke:
     name: Scan smoke

--- a/.github/workflows/aislop.yml
+++ b/.github/workflows/aislop.yml
@@ -1,15 +1,41 @@
-name: aislop
+name: Aislop checks
 
 on:
   push:
-    branches: [main]
+    branches: [main, develop]
   pull_request:
+    branches: [main, develop]
   workflow_dispatch:
 
 permissions:
   contents: read
 
 jobs:
+  build:
+    name: Build & test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: pnpm/action-setup@v5
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Typecheck
+        run: pnpm typecheck
+
+      - name: Build
+        run: pnpm build
+
+      - name: Test
+        run: pnpm vitest run
+
   scan-smoke:
     name: Scan smoke
     runs-on: ubuntu-latest
@@ -43,5 +69,8 @@ jobs:
         with:
           node-version: 22
           cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
 
       - run: npx aislop@latest ci .


### PR DESCRIPTION
Makes the PR checks easier to read and more complete: adds a visible build/test job, keeps the dedicated aislop scan smoke and quality gate, and runs the workflow on both main and develop. This is the develop-first version of the dogfood checks.