### PR TITLE
ci: remove duplicate push runs

### DIFF
--- a/.github/workflows/aislop.yml
+++ b/.github/workflows/aislop.yml
@@ -1,8 +1,6 @@
 name: aislop
 
 on:
-  push:
-    branches: [main]
   pull_request:
   workflow_dispatch:
 


### PR DESCRIPTION
Remove push-triggered CI from the Aislop workflow so PRs only show one set of checks.