### PR TITLE
fix(contributors): include merged-PR authors so squash-merges don't drop external contributors

### DIFF
--- a/.github/scripts/render-contributors.mjs
+++ b/.github/scripts/render-contributors.mjs
@@ -43,6 +43,35 @@ async function searchGithub(email) {
 	return data.items?.[0]?.login ?? null;
 }
 
+// Workaround: squash merges hide external PR authors from `git log` (the merger is recorded as commit author), so pull merged-PR authors from the API too.
+async function fetchMergedPrAuthors() {
+	const token = process.env.GITHUB_TOKEN;
+	const repo = process.env.GITHUB_REPOSITORY;
+	if (!token || !repo) return [];
+	const logins = new Set();
+	for (let page = 1; page <= 10; page++) {
+		const res = await fetch(
+			`https://api.github.com/repos/${repo}/pulls?state=closed&per_page=100&page=${page}`,
+			{
+				headers: {
+					Authorization: `Bearer ${token}`,
+					Accept: "application/vnd.github+json",
+				},
+			},
+		);
+		if (!res.ok) break;
+		const prs = await res.json();
+		if (!Array.isArray(prs) || prs.length === 0) break;
+		for (const pr of prs) {
+			if (pr.merged_at && pr.user?.login && pr.user.type === "User") {
+				logins.add(pr.user.login);
+			}
+		}
+		if (prs.length < 100) break;
+	}
+	return [...logins];
+}
+
 async function resolve(email) {
 	const m = email.match(NOREPLY);
 	if (m) return m[1];
@@ -56,6 +85,10 @@ for (const [email, name] of seen) {
 	const login = await resolve(email);
 	if (!login) continue;
 	if (!collected.has(login)) collected.set(login, name);
+}
+
+for (const login of await fetchMergedPrAuthors()) {
+	if (!collected.has(login)) collected.set(login, login);
 }
 
 if (collected.size === 0) {


### PR DESCRIPTION
## Summary

Fixes the contributors workflow to include authors of squash-merged PRs. Previously, external contributors disappeared from the README after their PRs were squashed.

## Problem

The squash-merge policy makes the merger the commit author in `git log`. Contributors who only ship via squashed PRs don't appear in git history, so the workflow drops them when regenerating the contributors list.

## Solution

Script now fetches merged PR authors via GitHub API and unions them with git-log-derived authors.