### PR TITLE
copy(positioning): standards-layer-and-quality-gate framing + prominent per-edit hook section in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # aislop
 
-**The quality gate for agentic coding.**
+**The engineering standards layer and quality gate for AI-written code.**
 
 [![npm version](https://img.shields.io/npm/v/aislop.svg)](https://www.npmjs.com/package/aislop)
 [![npm downloads](https://img.shields.io/npm/dm/aislop.svg)](https://www.npmjs.com/package/aislop)
@@ -9,7 +9,19 @@
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](https://opensource.org/licenses/MIT)
 [![Node >= 20](https://img.shields.io/badge/node-%3E%3D20-brightgreen.svg)](https://nodejs.org)
 
-`aislop` scans the code your agent wrote and gives you one score, 0–100. It rolls formatters, linters, complexity limits, dependency audits, and an AI-slop detector into a single command. It auto-fixes what's safely fixable and hands the rest to your coding agent with full context.
+Define your standard once in `.aislop/config.yml` + `.aislop/rules.yml`. Every change your agent makes is held to it automatically. `aislop` catches the slop they leave behind (narrative comments, `as any`, swallowed errors, hallucinated imports, todo stubs), enforces the rules your team sets, and scores every change 0–100. 8+ languages. Deterministic — no LLM at runtime.
+
+### The killer feature: the per-edit hook
+
+Install once into your coding agent:
+
+```bash
+npx aislop hook install --claude    # also: --cursor, --codex, --gemini, --windsurf, --cline, --kilo, --antigravity, --copilot
+```
+
+After every `Edit` / `Write` your agent makes, `aislop` runs and feeds the diagnostics back into the agent's next turn as structured `additionalContext` (envelope: `aislop.hook.v1` — score, counts, findings, regression flag, suggested next steps). **The agent sees the score regression on the same turn it wrote the code, before you prompt again.** No more PR-time surprises; the slop never leaves the keystroke that produced it.
+
+CI is the second gate: `aislop ci` exits non-zero when score drops below your threshold, so the same standard is enforced on every PR.
 
 Every check is deterministic. Regex patterns, AST analysis, and standard tooling (Biome, oxlint, knip, ruff). Same code in, same score out. No API calls, no LLMs, no network dependency (except optional dependency audits). The name refers to what it *catches*.
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "aislop",
 	"version": "0.7.0",
-	"description": "Stop AI slop from shipping. A unified code quality CLI that catches the lazy patterns AI coding tools leave behind.",
+	"description": "The engineering standards layer and quality gate for AI-written code. Define your standard once. Every agent — Claude Code, Cursor, Codex — is held to it automatically, on every edit and every PR. Catches the slop they leave behind, enforces the rules your team sets. 8+ languages. Deterministic.",
 	"type": "module",
 	"bin": {
 		"aislop": "./dist/cli.js"


### PR DESCRIPTION
## Summary

Updates positioning and messaging to emphasize the dual value: engineering standards enforcement + quality gate.

## Changes

**README subhead**
- Before: "The quality gate for agentic coding."
- After: "The engineering standards layer and quality gate for AI-written code."

**First paragraph** — rewritten to focus on the define-once, enforce-everywhere model.

**New section: The killer feature: the per-edit hook** — prominently highlights one-command hook installation and what makes it different from PR-time tools.

**package.json description** — updated for npm registry with clearer language about language support and deterministic behavior.

## Why These Changes

The per-edit hook is the primary differentiator. It needs to be visible on first scroll.