### PR TITLE
fix(ci): remove pnpm cache from quality-gate job

### DIFF
--- a/.github/workflows/aislop.yml
+++ b/.github/workflows/aislop.yml
@@ -35,11 +35,8 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - uses: pnpm/action-setup@v5
-
       - uses: actions/setup-node@v6
         with:
           node-version: 22
-          cache: pnpm
 
       - run: npx aislop@latest ci .


### PR DESCRIPTION
## Summary

Fixes the workflow cache failure in PR #94 quality-gate job.

## Root Cause

The `quality-gate` job was configured with:
- `pnpm/action-setup@v5`
- `cache: pnpm` in setup-node

But it only runs `npx aislop@latest ci .` without ever installing dependencies, so no pnpm store directory gets created. When the post-run step tries to save the cache, it fails with:

```
Path Validation Error: Path(s) specified in the action for caching
do(es) not exist, hence no cache is being saved.
```

## Fix

Removed `pnpm/action-setup` and `cache: pnpm` from the `quality-gate` job since it only needs Node to run `npx`.

The `scan-smoke` job keeps pnpm caching since it runs `pnpm install` and `pnpm build`.

## Testing

This should allow PR #94 (develop → main) to pass CI.