### PR TITLE
feat: rename action to 'aislop Quality Gate' for Marketplace

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -1,4 +1,4 @@
-name: aislop
+name: aislop Quality Gate
 description: Run the aislop quality gate on AI-assisted code (scan + fail CI below threshold from .aislop/config.yml).
 author: Kenny Olawuwo
 branding:


### PR DESCRIPTION
## Summary

Renames the GitHub Action to make it publishable on GitHub Marketplace.

## Problem

The current action name `aislop` conflicts with the organization/package name and cannot be published to GitHub Marketplace. GitHub requires action names to be unique and not match existing actions, users, or organizations.

## Solution

Renamed the action to **`aislop Quality Gate`** which:
- ✅ Is unique and won't conflict
- ✅ Clearly describes what the action does
- ✅ Maintains brand recognition with "aislop"
- ✅ Allows publication to GitHub Marketplace

## Changes

- Updated `action.yml` line 1: `name: aislop` → `name: aislop Quality Gate`

## After Merge

Once this merges to `main` and is released, you can publish the action to GitHub Marketplace with:

1. Go to the repo homepage
2. Click "Publish this Action to the GitHub Marketplace"
3. Review the details and publish

The action will be discoverable as **scanaislop/aislop** with display name **aislop Quality Gate**.