### PR TITLE
fix(ai-slop): respect tsconfig path aliases in hallucinated-import detection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.8.3 (2026-05-13)
+
+Patch release fixing a hallucinated-import false positive on projects that use TypeScript `compilerOptions.paths` aliases.
+
+### Fixed
+
+- **Respect `tsconfig.json` / `jsconfig.json` path aliases in hallucinated-import detection.** Imports matching a declared path alias (e.g. `import x from "@/components/Foo"` when `paths: { "@/*": ["./src/*"] }` is set) are no longer flagged as hallucinated packages. Walks the root and every workspace package, reads `compilerOptions.paths`, and supports both wildcard (`@/*`) and exact (`#shared`) alias keys. Malformed tsconfig is skipped silently (degraded behavior — the detector still flags as before). Added 5 vitest cases covering wildcard, exact, workspace-scoped tsconfig, `jsconfig.json`, and the malformed-config fallback.
+
 ## 0.8.2 (2026-05-10)
 
 Patch release with false-positive reduction for narrative comments and dependency downgrade protection utilities.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "aislop",
-	"version": "0.8.2",
+	"version": "0.8.3",
 	"description": "The engineering standards layer and quality gate for AI-written code. Define your standard once. Every agent — Claude Code, Cursor, Codex — is held to it automatically, on every edit and every PR. Catches the slop they leave behind, enforces the rules your team sets. 8+ languages. Deterministic.",
 	"type": "module",
 	"bin": {

--- a/src/engines/ai-slop/hallucinated-imports.ts
+++ b/src/engines/ai-slop/hallucinated-imports.ts
@@ -144,6 +144,44 @@ const collectJsDeps = (rootDir: string, jsDeps: Set<string>): boolean => {
 	return true;
 };
 
+type AliasMatcher = (spec: string) => boolean;
+
+const TS_CONFIG_FILES = ["tsconfig.json", "jsconfig.json"];
+
+const buildAliasMatcher = (key: string): AliasMatcher => {
+	const starIdx = key.indexOf("*");
+	if (starIdx === -1) {
+		return (spec) => spec === key;
+	}
+	const before = key.slice(0, starIdx);
+	const after = key.slice(starIdx + 1);
+	return (spec) =>
+		spec.length >= before.length + after.length && spec.startsWith(before) && spec.endsWith(after);
+};
+
+const collectAliasMatchersFromConfig = (configPath: string, matchers: AliasMatcher[]): void => {
+	const config = readJson(configPath) as Record<string, unknown> | null;
+	const opts = config?.compilerOptions;
+	if (!opts || typeof opts !== "object") return;
+	const paths = (opts as Record<string, unknown>).paths;
+	if (!paths || typeof paths !== "object") return;
+	for (const key of Object.keys(paths as Record<string, unknown>)) {
+		matchers.push(buildAliasMatcher(key));
+	}
+};
+
+const collectTsPathAliases = (rootDir: string): AliasMatcher[] => {
+	const matchers: AliasMatcher[] = [];
+	const rootPkg = readJson(path.join(rootDir, "package.json"));
+	const dirs = [rootDir, ...expandWorkspaceDirs(rootDir, readWorkspaceGlobs(rootDir, rootPkg))];
+	for (const dir of dirs) {
+		for (const fname of TS_CONFIG_FILES) {
+			collectAliasMatchersFromConfig(path.join(dir, fname), matchers);
+		}
+	}
+	return matchers;
+};
+
 const addPyDep = (pyDeps: Set<string>, name: string): void => {
 	const normalized = name.toLowerCase().replace(/_/g, "-");
 	pyDeps.add(normalized);
@@ -321,10 +359,15 @@ const extractPyImports = (content: string): { spec: string; line: number }[] => 
 	return results;
 };
 
-const checkJsImport = (spec: string, manifest: PackageManifest): string | null => {
+const checkJsImport = (
+	spec: string,
+	manifest: PackageManifest,
+	tsAliasMatchers: AliasMatcher[],
+): string | null => {
 	if (isJsRelativeOrAbsolute(spec)) return null;
 	if (isJsBuiltin(spec)) return null;
 	if (isJsVirtualModule(spec)) return null;
+	if (tsAliasMatchers.some((m) => m(spec))) return null;
 	const pkg = packageNameFromImport(spec);
 	if (manifest.jsDeps.has(pkg)) return null;
 	// Allow @types/X if X itself is in deps (the runtime impl) — common pattern.
@@ -348,6 +391,7 @@ const checkPyImport = (spec: string, manifest: PackageManifest): string | null =
 export const detectHallucinatedImports = async (context: EngineContext): Promise<Diagnostic[]> => {
 	const manifest = loadManifest(context.rootDirectory);
 	if (!manifest.hasJsManifest && !manifest.hasPyManifest) return [];
+	const tsAliasMatchers = manifest.hasJsManifest ? collectTsPathAliases(context.rootDirectory) : [];
 
 	const diagnostics: Diagnostic[] = [];
 	const files = getSourceFiles(context);
@@ -371,7 +415,9 @@ export const detectHallucinatedImports = async (context: EngineContext): Promise
 
 		const imports = isJs ? extractJsImports(content) : extractPyImports(content);
 		for (const { spec, line } of imports) {
-			const hallucinated = isJs ? checkJsImport(spec, manifest) : checkPyImport(spec, manifest);
+			const hallucinated = isJs
+				? checkJsImport(spec, manifest, tsAliasMatchers)
+				: checkPyImport(spec, manifest);
 			if (!hallucinated) continue;
 			const manifestLabel = isJs ? "package.json" : "requirements.txt / pyproject.toml / Pipfile";
 			diagnostics.push({

--- a/tests/hallucinated-imports.test.ts
+++ b/tests/hallucinated-imports.test.ts
@@ -231,6 +231,89 @@ const m2 = await import("ghost-package-esm")
 		expect(messages.some((m) => m.includes("ghost-package-cjs"))).toBe(true);
 		expect(messages.some((m) => m.includes("ghost-package-esm"))).toBe(true);
 	});
+
+	it("does not flag imports that match a tsconfig path alias with a wildcard", async () => {
+		writePkgJson({ react: "^19.0.0" });
+		writeFile(
+			"tsconfig.json",
+			JSON.stringify({
+				compilerOptions: { baseUrl: ".", paths: { "@/*": ["./src/*"] } },
+			}),
+		);
+		writeFile(
+			"src/app.ts",
+			`import { Button } from "@/components/Button";
+import { useThing } from "@/hooks/useThing";
+import { foo } from "@/lib/foo";
+import { Page } from "@/pages/Home";
+`,
+		);
+		const diags = await detectHallucinatedImports(buildContext());
+		expect(diags).toEqual([]);
+	});
+
+	it("does not flag an exact tsconfig path alias (no wildcard)", async () => {
+		writePkgJson({});
+		writeFile(
+			"tsconfig.json",
+			JSON.stringify({
+				compilerOptions: { baseUrl: ".", paths: { "#shared": ["./shared.ts"] } },
+			}),
+		);
+		writeFile("src/index.ts", `import { x } from "#shared";\n`);
+		const diags = await detectHallucinatedImports(buildContext());
+		expect(diags).toEqual([]);
+	});
+
+	it("reads tsconfig path aliases from each workspace package", async () => {
+		writeFile(
+			"package.json",
+			JSON.stringify({ name: "root", workspaces: ["packages/*"], dependencies: {} }),
+		);
+		writeFile(
+			"packages/web/package.json",
+			JSON.stringify({ name: "@scope/web", dependencies: { react: "^19.0.0" } }),
+		);
+		writeFile(
+			"packages/web/tsconfig.json",
+			JSON.stringify({
+				compilerOptions: { baseUrl: ".", paths: { "@/*": ["./src/*"] } },
+			}),
+		);
+		writeFile(
+			"packages/web/src/main.ts",
+			`import { Layout } from "@/components/Layout";\n`,
+		);
+		const diags = await detectHallucinatedImports(buildContext());
+		expect(diags).toEqual([]);
+	});
+
+	it("reads path aliases from jsconfig.json as well as tsconfig.json", async () => {
+		writePkgJson({});
+		writeFile(
+			"jsconfig.json",
+			JSON.stringify({
+				compilerOptions: { baseUrl: ".", paths: { "~/*": ["./src/*"] } },
+			}),
+		);
+		writeFile("src/index.js", `import { z } from "~/utils/z";\n`);
+		const diags = await detectHallucinatedImports(buildContext());
+		expect(diags).toEqual([]);
+	});
+
+	it("falls back gracefully when tsconfig.json is malformed (no crash, no alias support)", async () => {
+		writePkgJson({});
+		// Trailing comma — invalid strict JSON. readJson returns null; we proceed without aliases.
+		writeFile(
+			"tsconfig.json",
+			`{ "compilerOptions": { "paths": { "@/*": ["./src/*"], }, }, }`,
+		);
+		writeFile("src/index.ts", `import { x } from "@/lib/x";\n`);
+		const diags = await detectHallucinatedImports(buildContext());
+		// Without alias support, this DOES flag — that's the documented degraded behavior, not a regression.
+		expect(diags).toHaveLength(1);
+		expect(diags[0].message).toContain("@/lib");
+	});
 });
 
 describe("detectHallucinatedImports — Python", () => {


### PR DESCRIPTION
## Error

Imports matching a TypeScript `compilerOptions.paths` alias (e.g. `import x from "@/components/Foo"` when `paths: { "@/*": ["./src/*"] }`) were flagged as hallucinated packages. Reproduced on a real Vite + workspace project: 146 false-positive errors on a single repo, scoring it 1/100.

## Fix

`detectHallucinatedImports` now reads `tsconfig.json` / `jsconfig.json` from the project root and every workspace package, extracts `compilerOptions.paths`, and skips imports matching any alias key. Wildcard (`@/*`) and exact (`#shared`) keys both supported. Malformed config (e.g. JSONC trailing commas) is skipped silently — same flagging behavior as before, no regression.

## Tests

- 5 new vitest cases in `tests/hallucinated-imports.test.ts`: wildcard alias, exact alias, workspace-scoped tsconfig, `jsconfig.json`, malformed-config fallback.
- File suite: 24/24 passed (was 19/19).
- Full suite: 767/767 passed.
- `pnpm typecheck`: clean.
- aislop self-scan: 100/100 Healthy.
- Re-verified against the original repro project: 146 false positives → 0; remaining diagnostics on that repo are all real signal.