### PR TITLE
chore: format files touched by #47

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -54,16 +54,10 @@ const runScan = async (directory: string, flags: ScanFlags): Promise<void> => {
 	const config = loadConfig(directory);
 	const finalConfig = {
 		...config,
-		exclude: [
-			...(config.exclude ?? []),
-			...(flags.exclude ?? []),
-		],
-		include: [
-			...(config.include ?? []),
-			...(flags.include ?? []),
-		],
+		exclude: [...(config.exclude ?? []), ...(flags.exclude ?? [])],
+		include: [...(config.include ?? []), ...(flags.include ?? [])],
 	};
-	const {exitCode} = await scanCommand(directory, finalConfig, {
+	const { exitCode } = await scanCommand(directory, finalConfig, {
 		changes: Boolean(flags.changes),
 		staged: Boolean(flags.staged),
 		verbose: Boolean(flags.verbose),
@@ -160,12 +154,13 @@ program
 		"comma-separated or repeatable list of paths and files to exclude",
 		commaSeparatedParser,
 		[],
-	).option(
-	"--include <patterns>",
-	"comma-separated or repeatable list of paths and files to include",
-	commaSeparatedParser,
-	[],
-)
+	)
+	.option(
+		"--include <patterns>",
+		"comma-separated or repeatable list of paths and files to include",
+		commaSeparatedParser,
+		[],
+	)
 	.action(async (directory = ".", _flags, command) => {
 		await runScan(directory, command.optsWithGlobals() as ScanFlags);
 	});
@@ -222,7 +217,7 @@ program
 	.action(async (directory = ".", _flags, command) => {
 		const flags = command.optsWithGlobals() as { strict?: boolean };
 		await withCommandLifecycle(
-			{command: "init", config: loadConfig(directory).telemetry},
+			{ command: "init", config: loadConfig(directory).telemetry },
 			async () => {
 				await initCommand(directory, { strict: Boolean(flags.strict) });
 				return { exitCode: 0 };

--- a/src/config/defaults.ts
+++ b/src/config/defaults.ts
@@ -1,4 +1,4 @@
-import type {AislopConfig} from "./schema.js";
+import type { AislopConfig } from "./schema.js";
 
 export const DEFAULT_CONFIG: AislopConfig = {
 	version: 1,

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -1,4 +1,4 @@
-import {z} from "zod/v4";
+import { z } from "zod/v4";
 
 const DEFAULT_WEIGHTS: Record<string, number> = {
 	format: 0.3,
@@ -81,7 +81,7 @@ const AislopConfigSchema = z.object({
 		auditTimeout: 25000,
 	})),
 	scoring: ScoringSchema.default(() => ({
-		weights: {...DEFAULT_WEIGHTS},
+		weights: { ...DEFAULT_WEIGHTS },
 		thresholds: {
 			good: 75,
 			ok: 50,
@@ -114,7 +114,7 @@ const preMergeWeights = (raw: Record<string, unknown>): void => {
 	const userWeights = scoring.weights as Record<string, number> | undefined;
 	if (!userWeights || typeof userWeights !== "object") return;
 
-	scoring.weights = {...DEFAULT_WEIGHTS, ...userWeights};
+	scoring.weights = { ...DEFAULT_WEIGHTS, ...userWeights };
 };
 
 export const parseConfig = (raw: unknown): AislopConfig => {

--- a/src/utils/source-files.ts
+++ b/src/utils/source-files.ts
@@ -246,25 +246,27 @@ export const filterProjectFiles = (
 		});
 	};
 
-	return normalizedFiles.filter(({absolutePath, relativePath}) => {
-		if (
-			!fs.existsSync(absolutePath) ||
-			!isWithinProject(relativePath) ||
-			isExcludedPath(relativePath) ||
-			isTestFile(relativePath) ||
-			ignoredPaths.has(relativePath)
-		) {
-			return false;
-		}
-		if (!isUserIncluded(relativePath)) {
-			return false;
-		}
-		// exclude precedence over include
-		if (isUserExcluded(relativePath)) {
-			return false;
-		}
-		return hasAllowedExtension(relativePath, extraSet);
-	}).map(({absolutePath}) => absolutePath);
+	return normalizedFiles
+		.filter(({ absolutePath, relativePath }) => {
+			if (
+				!fs.existsSync(absolutePath) ||
+				!isWithinProject(relativePath) ||
+				isExcludedPath(relativePath) ||
+				isTestFile(relativePath) ||
+				ignoredPaths.has(relativePath)
+			) {
+				return false;
+			}
+			if (!isUserIncluded(relativePath)) {
+				return false;
+			}
+			// exclude precedence over include
+			if (isUserExcluded(relativePath)) {
+				return false;
+			}
+			return hasAllowedExtension(relativePath, extraSet);
+		})
+		.map(({ absolutePath }) => absolutePath);
 };
 
 const filterExplicitFiles = (


### PR DESCRIPTION
## Summary

Pure formatting cleanup. Ran \`aislop fix -f\` to clear 4 auto-fixable \`formatting\` warnings that landed with #47 in \`src/cli.ts\`, \`src/config/defaults.ts\`, \`src/config/schema.ts\`, and \`src/utils/source-files.ts\`. No logic changes.

## Why

Pre-release dogfood showed develop at **94 / 100** after #47 merged — all four findings were auto-fixable formatting drift. Cleared via our own \`fix -f\` so the self-scan returns to 100 / 100 before the v0.9.1 release PR (#114) merges.

## Validation

- \`node dist/cli.js fix -f\` → 4 resolved, 0 remain
- Self-scan: **100 / 100 Healthy, 0 issues**
- \`pnpm test\` — full suite passing

## Test plan

- [x] CI green
- [x] Merge before #114 so the release ships on a clean 100 / 100 develop