### PR TITLE
fix(scan): restore isBuildCacheFile in the source-file filter chain

### DIFF
--- a/src/utils/source-files.ts
+++ b/src/utils/source-files.ts
@@ -253,6 +253,7 @@ export const filterProjectFiles = (
 				!isWithinProject(relativePath) ||
 				isExcludedPath(relativePath) ||
 				isTestFile(relativePath) ||
+				isBuildCacheFile(relativePath) ||
 				ignoredPaths.has(relativePath)
 			) {
 				return false;

--- a/tests/source-files.test.ts
+++ b/tests/source-files.test.ts
@@ -87,4 +87,44 @@ describe("source file selection", () => {
 
 		expect(sourceFiles).toEqual([path.join(tmpDir, "src/app.py")]);
 	});
+
+	it("excludes Vite config-bundle timestamp cache files even when tracked", () => {
+		createFile(tmpDir, "src/app.ts", "export const app = true;\n");
+		createFile(
+			tmpDir,
+			"apps/storybook/vite.config.ts.timestamp-1735325995918-46a167c39672.mjs",
+			"// vite cache\n",
+		);
+		createFile(
+			tmpDir,
+			"apps/web/vite.config.ts.timestamp-1700000000000-abc123def456.cjs",
+			"// vite cache\n",
+		);
+		createFile(tmpDir, "src/normal.timestamp-1.mjs", "// not a cache file\n");
+
+		git(tmpDir, [
+			"add",
+			"-f",
+			"src/app.ts",
+			"apps/storybook/vite.config.ts.timestamp-1735325995918-46a167c39672.mjs",
+			"apps/web/vite.config.ts.timestamp-1700000000000-abc123def456.cjs",
+			"src/normal.timestamp-1.mjs",
+		]);
+		git(tmpDir, [
+			"-c",
+			"user.email=t@t",
+			"-c",
+			"user.name=t",
+			"commit",
+			"-m",
+			"seed",
+		]);
+
+		const sourceFiles = getSourceFilesForRoot(tmpDir).sort();
+
+		expect(sourceFiles).toEqual([
+			path.join(tmpDir, "src/app.ts"),
+			path.join(tmpDir, "src/normal.timestamp-1.mjs"),
+		]);
+	});
 });


### PR DESCRIPTION
## What

Restore the `isBuildCacheFile` call in `filterProjectFiles`. PR #113 added it; PR #47 (the `--include` rewrite) dropped it. The helper survives in code, but the source-file walk stopped using it.

## Why it matters

Vite cache files (`*.timestamp-NNN-XXX.{js,mjs,cjs}`) get scanned again. Repos that commit those files (e.g. `CapSoftware/Cap`) surface 3 false-positive `ai-slop/hallucinated-import` errors on every scan.

## Fix

```diff
   if (
     !fs.existsSync(absolutePath) ||
     !isWithinProject(relativePath) ||
     isExcludedPath(relativePath) ||
     isTestFile(relativePath) ||
+    isBuildCacheFile(relativePath) ||
     ignoredPaths.has(relativePath)
   ) return false;
```

Plus a regression test in `tests/source-files.test.ts` so the next filter refactor can't quietly drop it again.

## Validation

- `pnpm test` — 798/798 pass
- `pnpm build` ✅
- Self-scan: 100/100