### PR TITLE
chore: release v0.9.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.9.2 (2026-05-19)
+
+Patch fix for a regression introduced during the 0.9.1 merge.
+
+### Fixed
+
+- **Restore `isBuildCacheFile` in the source-file filter (#117).** PR #113 added an exclusion for Vite config-bundle cache artifacts (`*.timestamp-NNN-XXX.{js,mjs,cjs}`); PR #47's `--include` rewrite of the filter chain dropped the call. The helper survived in code but stopped being consulted by the source-file walk, so repos that commit those cache files (e.g. via Storybook's `vite.config.ts.timestamp-…mjs`) saw three spurious `ai-slop/hallucinated-import` errors per scan. Restored the call and added a regression test that creates real Vite cache filenames plus one false-match to guard against future filter rewrites.
+
 ## 0.9.1 (2026-05-19)
 
 Patch release focused on accuracy and signal quality on real-world projects: fewer false positives on Vite, Next.js, SolidStart, SST, and Bun setups; smarter complexity thresholds per language and per role; vulnerable-dependency aggregation per package; a new top-rules breakdown in scan output; `--include` pattern support on `scan`; scan-stability hardening; and an enterprise-friendly `init --strict` mode.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "aislop",
-	"version": "0.9.1",
+	"version": "0.9.2",
 	"description": "The engineering standards layer and quality gate for AI-written code. Define your standard once. Every agent — Claude Code, Cursor, Codex — is held to it automatically, on every edit and every PR. Catches the slop they leave behind, enforces the rules your team sets. 8+ languages. Deterministic.",
 	"type": "module",
 	"bin": {


### PR DESCRIPTION
## What

Patch release for the regression in 0.9.1 that re-enabled scanning of Vite cache files.

## Included

- **#117** — restore `isBuildCacheFile` in `filterProjectFiles`; PR #47's filter rewrite dropped the call

## Validation

- `pnpm test` — 798/798 pass
- `pnpm build` ✅
- Self-scan: 100/100

## Test plan

- [ ] CI green
- [ ] Promote develop → main after merge
- [ ] Tag v0.9.2, publish to npm