### PR TITLE
fix(security): skip keyword-prefixed secret matches inside string-literal prose

### DIFF
--- a/src/engines/security/secrets.ts
+++ b/src/engines/security/secrets.ts
@@ -3,22 +3,32 @@ import path from "node:path";
 import { getSourceFilesWithExtras } from "../../utils/source-files.js";
 import type { Diagnostic, EngineContext } from "../types.js";
 
-const SECRET_PATTERNS: Array<{ pattern: RegExp; name: string }> = [
+interface SecretPattern {
+	pattern: RegExp;
+	name: string;
+	// Skip the match when the keyword sits inside a string literal (prose, not an identifier).
+	keywordPrefixed?: boolean;
+}
+
+const SECRET_PATTERNS: SecretPattern[] = [
 	// API Keys
 	{
 		pattern: /(?:api[_-]?key|apikey)\s*[:=]\s*["']([A-Za-z0-9_-]{20,})["']/gi,
 		name: "API key",
+		keywordPrefixed: true,
 	},
 	// AWS
 	{ pattern: /AKIA[0-9A-Z]{16}/g, name: "AWS Access Key" },
 	{
 		pattern: /(?:aws[_-]?secret|secret[_-]?key)\s*[:=]\s*["']([A-Za-z0-9/+=]{40})["']/gi,
 		name: "AWS Secret Key",
+		keywordPrefixed: true,
 	},
 	// Generic secrets/passwords
 	{
 		pattern: /(?:password|passwd|pwd|secret)\s*[:=]\s*["']([^"']{8,})["']/gi,
 		name: "Hardcoded password/secret",
+		keywordPrefixed: true,
 	},
 	// Private keys
 	{
@@ -34,6 +44,7 @@ const SECRET_PATTERNS: Array<{ pattern: RegExp; name: string }> = [
 	{
 		pattern: /(?:token|bearer)\s*[:=]\s*["']([A-Za-z0-9_-]{20,})["']/gi,
 		name: "Authentication token",
+		keywordPrefixed: true,
 	},
 	// GitHub tokens
 	{ pattern: /gh[pousr]_[A-Za-z0-9_]{36,}/g, name: "GitHub token" },
@@ -45,6 +56,25 @@ const SECRET_PATTERNS: Array<{ pattern: RegExp; name: string }> = [
 		name: "Database connection string with credentials",
 	},
 ];
+
+const isInsideStringLiteral = (content: string, matchIndex: number): boolean => {
+	const lineStart = content.lastIndexOf("\n", matchIndex - 1) + 1;
+	const prefix = content.slice(lineStart, matchIndex);
+	let inDouble = false;
+	let inSingle = false;
+	let inBacktick = false;
+	for (let i = 0; i < prefix.length; i++) {
+		const ch = prefix[i];
+		if (ch === "\\") {
+			i++;
+			continue;
+		}
+		if (ch === '"' && !inSingle && !inBacktick) inDouble = !inDouble;
+		else if (ch === "'" && !inDouble && !inBacktick) inSingle = !inSingle;
+		else if (ch === "`" && !inDouble && !inSingle) inBacktick = !inBacktick;
+	}
+	return inDouble || inSingle || inBacktick;
+};
 
 const PLACEHOLDER_EXACT = new Set(["changeme", "password", "secret", "xxx", "todo", "replace_me"]);
 
@@ -73,13 +103,14 @@ export const scanSecrets = async (context: EngineContext): Promise<Diagnostic[]>
 
 		const relativePath = path.relative(context.rootDirectory, filePath);
 
-		for (const { pattern, name } of SECRET_PATTERNS) {
+		for (const { pattern, name, keywordPrefixed } of SECRET_PATTERNS) {
 			const regex = new RegExp(pattern.source, pattern.flags);
 			let match: RegExpExecArray | null;
 
 			while ((match = regex.exec(content)) !== null) {
 				const matchedText = match[1] ?? match[0];
 				if (isPlaceholderValue(matchedText)) continue;
+				if (keywordPrefixed && isInsideStringLiteral(content, match.index)) continue;
 
 				const line = content.slice(0, match.index).split("\n").length;
 

--- a/tests/security.test.ts
+++ b/tests/security.test.ts
@@ -77,6 +77,38 @@ describe("scanSecrets", () => {
 		expect(diagnostics[0].message).toContain("password");
 	});
 
+	it("does not flag keyword-prefixed matches inside string-literal prose (log calls)", async () => {
+		const filePath = writeFile(
+			"actions.ts",
+			[
+				"async function update() {",
+				"  try {",
+				"    await db.set();",
+				"  } catch (error) {",
+				'    console.error("Error verifying video password:", error);',
+				'    console.log("API key rotation failed:", error);',
+				'    log.warn(`token refresh: ${err.message}`);',
+				"  }",
+				"}",
+			].join("\n"),
+		);
+		const diagnostics = await scanSecrets(makeContext([filePath]));
+		expect(diagnostics).toHaveLength(0);
+	});
+
+	it("still flags the same keywords when they are real identifiers", async () => {
+		const filePath = writeFile(
+			"mixed.ts",
+			[
+				'const password = "super-secret-password-123";',
+				'console.error("Error verifying video password:", error);',
+			].join("\n"),
+		);
+		const diagnostics = await scanSecrets(makeContext([filePath]));
+		expect(diagnostics).toHaveLength(1);
+		expect(diagnostics[0].line).toBe(1);
+	});
+
 	it("detects a private key header", async () => {
 		const filePath = writeFile(
 			"keys.ts",


### PR DESCRIPTION
## What

`security/hardcoded-secret` patterns anchored on a keyword (`password`, `api_key`, `token`, `secret_key`, ...) now skip matches where the keyword sits inside an unclosed string literal on the same line. Pure-value patterns (AKIA, JWT, `gh[pousr]_`, `xox[baprs]`, private-key headers, DB URLs) are unaffected.

## Why

`console.error("Error verifying video password:", error)` was producing three false positives on every public Cap scan because the regex `(?:password|...)\s*[:=]\s*["']([^"']{8,})["']` matched the prose as if it were a real `password = "..."` assignment.

## Fix

```diff
- const SECRET_PATTERNS: Array<{ pattern: RegExp; name: string }> = [
+ interface SecretPattern { pattern: RegExp; name: string; keywordPrefixed?: boolean; }
+ const SECRET_PATTERNS: SecretPattern[] = [
    { pattern: /(?:password|passwd|pwd|secret).../, name: "...",
+     keywordPrefixed: true,
    },
    { pattern: /AKIA[0-9A-Z]{16}/g, name: "AWS Access Key" },  // unchanged
    ...
  ];

+ // Skip when keyword is inside an unclosed string literal on the same line.
+ if (keywordPrefixed && isInsideStringLiteral(content, match.index)) continue;
```

`isInsideStringLiteral` walks the line prefix and tracks `"`, `'`, backtick balance (respecting `\` escapes).

## Regression tests

- File with `console.error("... password:", err)` + `console.log("API key rotation failed:", err)` + backtick `log.warn` — expects **0** findings.
- File with `const password = "..."` AND a log-call prose match in the same file — expects **1** finding, on the real assignment line.

## Validation

- `pnpm test` — 800/800 pass (2 new)
- `pnpm build` ✅
- Self-scan: 100/100