### PR TITLE
docs(community): enable Discussions surface

### DIFF
--- a/.github/DISCUSSION_TEMPLATE/false-positive.yml
+++ b/.github/DISCUSSION_TEMPLATE/false-positive.yml
@@ -1,0 +1,34 @@
+title: "[FP] "
+labels: ["false-positive"]
+body:
+  - type: input
+    id: rule
+    attributes:
+      label: Rule name
+      description: e.g. ai-slop/narrative-comment, code-quality/duplicate-block
+      placeholder: ai-slop/narrative-comment
+    validations:
+      required: true
+  - type: textarea
+    id: snippet
+    attributes:
+      label: Code snippet
+      description: The code aislop flagged. 3-5 lines of context is plenty.
+      render: typescript
+    validations:
+      required: true
+  - type: textarea
+    id: reasoning
+    attributes:
+      label: Why you think it's a false positive
+      placeholder: e.g. The comment isn't narrative, it's documenting a non-obvious invariant.
+    validations:
+      required: true
+  - type: input
+    id: version
+    attributes:
+      label: aislop version
+      description: Output of `aislop --version`
+      placeholder: 0.9.3
+    validations:
+      required: true

--- a/.github/DISCUSSION_TEMPLATE/rule-request.yml
+++ b/.github/DISCUSSION_TEMPLATE/rule-request.yml
@@ -1,0 +1,35 @@
+title: "[Rule] "
+labels: ["rule-request"]
+body:
+  - type: textarea
+    id: pattern
+    attributes:
+      label: The pattern you want flagged
+      description: Show the kind of code you think aislop should catch.
+      render: typescript
+    validations:
+      required: true
+  - type: textarea
+    id: should-pass
+    attributes:
+      label: Code that should NOT trigger the rule
+      description: Help us distinguish the slop from the legitimate version of the same shape.
+      render: typescript
+  - type: input
+    id: name-suggestion
+    attributes:
+      label: Suggested rule name (optional)
+      placeholder: ai-slop/redundant-validation
+  - type: dropdown
+    id: language
+    attributes:
+      label: Language
+      options:
+        - TypeScript / JavaScript
+        - Python
+        - Go
+        - Rust
+        - Ruby
+        - PHP
+        - Java
+        - Multiple

--- a/README.md
+++ b/README.md
@@ -265,6 +265,10 @@ See the full [rules reference](docs/rules.md).
 
 [Installation](docs/installation.md) · [Commands](docs/commands.md) · [Rules](docs/rules.md) · [Config](docs/configuration.md) · [Scoring](docs/scoring.md) · [CI/CD](docs/ci.md) · [Telemetry](docs/telemetry.md)
 
+## Community
+
+[Discussions](https://github.com/scanaislop/aislop/discussions) for questions, rule requests, and false-positive triage · [Issues](https://github.com/scanaislop/aislop/issues) for bugs
+
 ## Contributing
 
 See [CONTRIBUTING.md](CONTRIBUTING.md). AI assistants: [AGENTS.md](AGENTS.md).


### PR DESCRIPTION
## Summary

Spin up GitHub Discussions as the primary community surface. Three changes:

- `.github/DISCUSSION_TEMPLATE/false-positive.yml` — structured form for false-positive reports (rule name, snippet, reasoning, CLI version)
- `.github/DISCUSSION_TEMPLATE/rule-request.yml` — structured form for rule requests (pattern, what should pass, suggested name, language)
- `README.md` — add a one-line `## Community` block linking Discussions and Issues, between `## Docs` and `## Contributing`

Discussions is already enabled on the repo (`has_discussions=true`). Default categories (Announcements, General, Ideas, Q&A, Show and tell) cover the planned flows; no category changes needed at this stage.

## Test plan
- [x] README renders cleanly with the new section between Docs and Contributing
- [x] Both YAML templates parse as valid GitHub Discussion forms
- [ ] Manual after merge: open new discussion → template picker shows the two forms; pinned welcome post + 3 seed posts will land separately