### PR TITLE
feat(cli): print one-line star CTA after scan output

### DIFF
--- a/src/commands/scan.ts
+++ b/src/commands/scan.ts
@@ -14,6 +14,7 @@ import { log } from "../ui/logger.js";
 import {
 	type BreakdownSummary,
 	renderCleanRun,
+	renderStarCta,
 	renderSummary,
 	type NextStep,
 } from "../ui/summary.js";
@@ -125,11 +126,13 @@ export const buildScanRender = (input: BuildScanRenderInput): string => {
 		(d) => d.rule === "security/vulnerable-dependency",
 	);
 
+	const starCta = input.printBrand !== false ? renderStarCta(deps) : "";
+
 	if (input.diagnostics.length === 0 && input.score.score === 100) {
 		return `${header}${renderCleanRun(
 			{ score: input.score.score, label: input.score.label, elapsedMs: input.elapsedMs },
 			deps,
-		)}`;
+		)}${starCta}`;
 	}
 
 	const diagBlock =
@@ -172,7 +175,7 @@ export const buildScanRender = (input: BuildScanRenderInput): string => {
 		deps,
 	);
 
-	return `${header}${diagBlock}${summary}`;
+	return `${header}${diagBlock}${summary}${starCta}`;
 };
 
 export const scanCommand = async (

--- a/src/ui/summary.ts
+++ b/src/ui/summary.ts
@@ -130,6 +130,11 @@ export const renderSummary = (input: SummaryInput, deps: SummaryDeps = {}): stri
 	return lines.join("\n");
 };
 
+export const renderStarCta = (deps: SummaryDeps = {}): string => {
+	const t = deps.theme ?? defaultTheme;
+	return `\n ${style(t, "muted", "★ Found this useful? Star us at github.com/scanaislop/aislop")}\n`;
+};
+
 export const renderCleanRun = (
 	input: { score?: number; label?: string; elapsedMs: number },
 	deps: SummaryDeps = {},


### PR DESCRIPTION
## Summary

Adds a single muted line to the end of `aislop scan` output:

```
 ★ Found this useful? Star us at github.com/scanaislop/aislop
```

## Why

Visitors who try the CLI via `npx aislop scan` currently have no in-CLI nudge back to the repo. The output ends with the score and the next-steps block.

## Where it shows

- `aislop scan` (any flavour, with or without findings)

## Where it doesn't

- `--json` output (JSON path returns early before reaching the renderer)
- `aislop ci` (defaults to JSON; `--human` flag falls through to the renderer, where the CTA does show — acceptable since human ci is rare)
- Hook integrations and any caller that passes `printBrand: false` (the existing brand gate covers it)

## Test plan
- [x] `pnpm test` → all 842 tests pass
- [x] aislop self-scan → 100/100, 0 findings
- [x] Manual: `node dist/cli.js scan` against the repo renders the CTA at the bottom
- [x] Manual: `node dist/cli.js scan --json` does not include the CTA