### PR TITLE
chore(npm): align package description with README and GitHub About

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "aislop",
   "version": "0.9.4",
-  "description": "The engineering standards layer and quality gate for AI-written code. Define your standard once. Every agent — Claude Code, Cursor, Codex — is held to it automatically, on every edit and every PR. Catches the slop they leave behind, enforces the rules your team sets. 8+ languages. Deterministic.",
+  "description": "Catch the slop AI coding agents leave in your code: narrative comments, swallowed exceptions, as-any casts, dead code, oversized functions. 40+ rules across 7 languages (TS/JS, Python, Go, Rust, Ruby, PHP, Java). Sub-second, deterministic, no LLM at runtime. MIT-licensed.",
   "type": "module",
   "bin": {
     "aislop": "./dist/cli.js",


### PR DESCRIPTION
## Summary

`package.json:description` still carried the old enterprise-speak phrasing ("The engineering standards layer and quality gate ..."). That's what npm shows on the package page and in search snippets, so it stayed visible after v0.9.4 even though the README, GitHub About, and marketing site all already use the verb-first version.

### Before

> The engineering standards layer and quality gate for AI-written code. Define your standard once. Every agent — Claude Code, Cursor, Codex — is held to it automatically, on every edit and every PR. Catches the slop they leave behind, enforces the rules your team sets. 8+ languages. Deterministic.

### After

> Catch the slop AI coding agents leave in your code: narrative comments, swallowed exceptions, as-any casts, dead code, oversized functions. 40+ rules across 7 languages (TS/JS, Python, Go, Rust, Ruby, PHP, Java). Sub-second, deterministic, no LLM at runtime. MIT-licensed.

## Test plan
- [x] aislop self-scan stays 100/100
- [ ] Ships with the next release; npm page reflects the new description after publish
