### PR TITLE
SARIF output, per-rule severity, trend command, config JSON schema, pre-commit hook

### DIFF
--- a/.aislop/config.yml
+++ b/.aislop/config.yml
@@ -1,5 +1,15 @@
 version: 1
 
+# editors/ is an isolated VS Code extension package with its own manifest;
+# it imports the host-provided `vscode` module, so exclude it from the root scan.
+exclude:
+  - node_modules
+  - .git
+  - dist
+  - build
+  - coverage
+  - editors
+
 engines:
   format: true
   lint: true

--- a/.gitignore
+++ b/.gitignore
@@ -10,4 +10,5 @@ CHANGELOG-review.md
 docs/superpowers/
 docs/specs/
 .aislop/session.jsonl
+.aislop/history.jsonl
 .aislop/hook.lock

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,0 +1,7 @@
+- id: aislop
+  name: aislop
+  description: Catch AI slop in staged files before they are committed.
+  entry: aislop scan --staged
+  language: node
+  pass_filenames: false
+  require_serial: true

--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@ npx aislop scan ./src     # specific directory
 npx aislop scan --changes # changed files from HEAD
 npx aislop scan --staged  # staged files only
 npx aislop scan --json    # JSON output
+npx aislop scan --sarif   # SARIF 2.1.0 output (GitHub code scanning)
 ```
 
 **Exclude files**: `node_modules`, `.git`, `dist`, `build`, `coverage` excluded by default. Add more in `.aislop/config.yml`:
@@ -89,6 +90,18 @@ exclude:
 
 Or via CLI: `npx aislop scan --exclude "**/*.test.ts,dist"`
 
+**Per-rule severity**: Override the severity of any rule by id, or turn it off:
+
+```yaml
+# .aislop/config.yml
+rules:
+  ai-slop/narrative-comment: warning   # error | warning | off
+  ai-slop/trivial-comment: "off"       # drop this rule entirely
+  security/hardcoded-secret: error
+```
+
+`off` drops matching diagnostics; `error`/`warning` rewrites severity before scoring and reporting. Absent map keeps default behavior.
+
 **Extend config**: Project config can extend a parent:
 
 ```yaml
@@ -97,6 +110,8 @@ extends: ../../.aislop/base.yml
 ci:
   failBelow: 80             # override specific keys
 ```
+
+**Editor validation**: Point your editor at the JSON Schema in [`schema/aislop.config.schema.json`](schema/aislop.config.schema.json) for autocomplete and validation of `.aislop/config.yml`. Regenerate it from the source config schema with `pnpm gen:schema`.
 
 ### Fix
 
@@ -177,8 +192,11 @@ npx aislop init                # create .aislop/config.yml
 npx aislop init --strict       # enterprise-grade gate: all engines, typecheck, failBelow 85
 npx aislop rules               # list rules
 npx aislop badge               # print badge URL
+npx aislop trend               # show score history over time
 npx aislop                     # interactive menu
 ```
+
+**Score history**: a normal (full-project, interactive) `scan` appends a compact record to `.aislop/history.jsonl` (timestamp, score, error/warning counts, file count, CLI version). `aislop trend` reads it and prints a table plus an ASCII sparkline of recent scores. History is a local side effect only: it is never written for `--json`/`--sarif` output, in CI, or when `AISLOP_NO_HISTORY=1` is set, so machine output stays clean.
 
 Docs: [commands](docs/commands.md)
 
@@ -188,8 +206,21 @@ Docs: [commands](docs/commands.md)
 
 ### Pre-commit
 
+Run directly on staged files:
+
 ```bash
 npx aislop scan --staged
+```
+
+Or wire it into the [pre-commit](https://pre-commit.com) framework via the bundled hook:
+
+```yaml
+# .pre-commit-config.yaml
+repos:
+  - repo: https://github.com/scanaislop/aislop
+    rev: v0.9.4
+    hooks:
+      - id: aislop
 ```
 
 ### GitHub Actions
@@ -209,6 +240,15 @@ Run `npx aislop init` and accept the workflow prompt, or add manually:
 ```yaml
 - uses: actions/checkout@v4
 - uses: scanaislop/aislop@v0.8
+```
+
+**GitHub code scanning (SARIF)**: emit a SARIF 2.1.0 report and upload it so findings appear in the Security tab:
+
+```yaml
+- run: npx aislop@latest scan . --sarif > aislop.sarif
+- uses: github/codeql-action/upload-sarif@v3
+  with:
+    sarif_file: aislop.sarif
 ```
 
 ### Quality gate
@@ -263,9 +303,15 @@ See the full [rules reference](docs/rules.md).
 
 ---
 
+## Research
+
+aislop rules are shaped by public scans and benchmark-derived failure modes, not only local fixtures. The [research program](docs/research-program.md) defines how to run repeatable open-source scans: pin the cohort, store raw JSON, classify findings, fix noisy rules with regression tests, and publish the limits.
+
+---
+
 ## Docs
 
-[Installation](docs/installation.md) · [Commands](docs/commands.md) · [Rules](docs/rules.md) · [Config](docs/configuration.md) · [Scoring](docs/scoring.md) · [CI/CD](docs/ci.md) · [Telemetry](docs/telemetry.md)
+[Installation](docs/installation.md) · [Commands](docs/commands.md) · [Rules](docs/rules.md) · [Config](docs/configuration.md) · [Scoring](docs/scoring.md) · [CI/CD](docs/ci.md) · [Telemetry](docs/telemetry.md) · [Research program](docs/research-program.md)
 
 ## Community
 

--- a/docs/plans/fix-to-pr.md
+++ b/docs/plans/fix-to-pr.md
@@ -1,0 +1,113 @@
+# Fix → Open PR
+
+A design spec for the automated `fix → open PR` flow. This needs a GitHub App,
+installation auth, and a server-side sandbox, so it is a specification rather than
+shippable code today.
+
+## Framing: the score is the gate
+
+aislop produces a single deterministic score from a scan (see `docs/scoring.md`).
+That determinism is the whole point of the flow: the LLM **proposes** edits, and the
+engine **scores** them. This is the "AlphaGo for code quality" loop — a strong but
+fallible generator paired with a cheap, deterministic evaluator. We only ever keep a
+change if the deterministic score improves. The LLM is never the judge of its own work.
+
+## User flow
+
+1. **Trigger.** A user starts a fix run from one of:
+   - the hosted dashboard ("Fix" button on a repo or a specific finding), or
+   - the CLI (`aislop fix --open-pr`, which calls the hosted API).
+2. The platform queues a job against a target repo + ref (default: the repo's
+   default branch HEAD).
+3. The job runs the loop (below) inside a sandbox.
+4. On success it opens a PR via the GitHub App and links it back in the dashboard.
+   On failure (no improvement, budget exceeded) it hands off with a summary and no PR.
+
+## The loop
+
+```
+clone repo @ ref  →  scan (baseline score S0)
+repeat up to N iterations:
+    aislop fix                      # mechanical fixers (deterministic)
+    if findings remain:
+        LLM proposes edits          # bounded, allowlisted patch
+    re-scan (score Si)
+    if Si > S(i-1):  keep changes (commit)
+    else:            revert this iteration's edits
+stop when: no findings left, OR no score gain for K iterations, OR budget hit
+if final score Sf > S0:  open PR
+else:                    hand off (post summary, no PR)
+```
+
+- `aislop fix` runs first each iteration because it is deterministic and free; the
+  LLM is only invoked for what the fixers cannot resolve.
+- Every kept iteration is a commit, so the PR history shows incremental, attributable
+  improvements.
+- The gate is strictly `Si > S(i-1)`: a tie or regression is reverted. The run as a
+  whole only opens a PR when `Sf > S0`.
+
+## Branch naming
+
+`aislop/fix/<id>` where `<id>` is the job id (short, URL-safe). One branch per run,
+created from the target ref. Never commit to `main` / the default branch — all
+output is a PR.
+
+## Opening the PR (Octokit + GitHub App)
+
+Using `@octokit/rest` authenticated as the installation (see auth model):
+
+1. Create the branch ref from the base sha.
+2. Push the iteration commits to `aislop/fix/<id>`.
+3. `pulls.create({ base, head: "aislop/fix/<id>", title, body })`.
+
+### PR body
+
+- **Score delta:** `S0 → Sf` with the absolute and percentage change, plus a
+  per-engine breakdown (format / lint / code-quality / ai-slop / architecture / security).
+- **Findings table:** what was resolved, grouped by engine and rule:
+
+  | File | Engine | Rule | Severity | Status |
+  | ---- | ------ | ---- | -------- | ------ |
+  | src/x.ts:42 | ai-slop | narrative-comment | warning | fixed |
+  | src/y.ts:13 | security | swallowed-error | error | fixed |
+
+- A short note listing anything left unresolved and why (handed off, not regressed).
+- Footer: aislop version + config hash so the result is reproducible.
+
+## Auth model
+
+- A **GitHub App** is installed on the org/repo. The server mints a short-lived
+  **installation access token** per job (via the App's JWT → installation token
+  exchange). Tokens are scoped to the target repo with `contents:write` and
+  `pull_requests:write`.
+- Tokens live only for the job's duration and are never persisted to disk or logs.
+- The App identity is the PR author, so changes are clearly attributable to aislop
+  and subject to the repo's normal branch protection and review.
+- **Never push to the default branch.** The App lacks (and is never granted) the
+  ability to bypass branch protection; output is always a PR.
+
+## Safety rails
+
+- **Sandbox.** Each job runs in an ephemeral, network-restricted container. Only the
+  cloned repo is writable; the GitHub token is injected as an env secret, not committed.
+- **Command allowlist.** The loop may run only `git`, `aislop`, and the project's
+  package-manager install/build/test commands resolved from the repo manifest. No
+  arbitrary shell from LLM output; proposed edits are applied as patches, not executed.
+- **Time + iteration budget.** Hard caps on wall-clock time, iteration count `N`, and
+  total LLM token spend per job. Exceeding any cap stops the loop and triggers handoff.
+- **Score-gated writes.** Nothing is committed unless the deterministic score improved;
+  this prevents the LLM from "fixing" by deleting code or disabling rules (those would
+  not improve the score, since rule config is read from the repo and not modifiable by
+  the job).
+- **No config tampering.** `.aislop/config.yaml` and `.aislop/rules.yaml` are treated
+  as read-only inputs in the sandbox so the gate cannot be gamed.
+
+## Where it slots into the hosted platform
+
+- **Dashboard / API** owns triggers, job queue, and result display.
+- **Worker** runs the sandboxed loop and shells out to the same `aislop` CLI used
+  everywhere else (CI, the VS Code extension, local dev), so scoring is identical
+  across surfaces.
+- **GitHub App service** handles installation-token minting and Octokit calls.
+- Results (score delta, PR link, handoff reasons) are written back to the dashboard
+  and surfaced in the originating CLI/dashboard session.

--- a/docs/research-program.md
+++ b/docs/research-program.md
@@ -1,0 +1,138 @@
+# aislop Research Program
+
+aislop should learn in public.
+
+The CLI is the distribution surface, but the moat is the corpus of repeatable AI-code-quality failures we can prove: real open-source repositories, pinned commits, raw JSON scan output, false-positive review, and detector changes that ship with regression tests.
+
+This document is the protocol for public scans and benchmark writeups.
+
+## Goals
+
+- Turn repeated AI-agent failure modes into deterministic rules.
+- Keep rule quality honest by scanning real projects, not only fixtures.
+- Publish methods and limits so research posts are credible.
+- Feed enterprise product strategy with evidence: which rules matter, where noise appears, and what teams need to govern AI-written code.
+
+## Scan Protocol
+
+For every public research run:
+
+1. Define the cohort before scanning.
+   - Examples: GitHub Trending by language, top npm packages, agent-generated benchmark tasks, framework repos, or a public customer-nominated list.
+   - Record the selection rule. Do not swap repos after seeing results unless the reason is disclosed.
+2. Pin every repository.
+   - Capture `owner/repo`, default branch, commit SHA, primary language, package manager, and whether install/build was attempted.
+3. Pin the scanner.
+   - Capture aislop version, Node version, OS, config file, enabled engines, and command.
+   - Preferred command: `npx aislop@<version> scan . --json`.
+4. Store raw output.
+   - Keep the JSON result for each repo before writing a summary.
+   - Never publish private source. Public repos are okay to quote sparingly with links.
+5. Classify findings.
+   - Sample the top findings per rule.
+   - Mark each sampled finding as true positive, false positive, needs-context, or toolchain/setup failure.
+6. Convert learning into product.
+   - False positive class -> tighten the detector and add regression tests.
+   - Repeated true positive class -> consider a named rule.
+   - Setup failure -> improve source filtering, language targeting, doctor output, or docs.
+7. Publish the method and the limit.
+   - Include cohort, command, version, high-level results, representative examples, and what changed in the CLI.
+   - Say what the scan does not prove.
+
+## Report Template
+
+```md
+# Title
+
+## Cohort
+
+- Selection rule:
+- Repositories:
+- Date scanned:
+- aislop version:
+- Command:
+
+## Headline Findings
+
+- Finding 1
+- Finding 2
+- Finding 3
+
+## Rule-Level Results
+
+| Rule | Findings | Sampled | True positives | False positives | Action |
+|---|---:|---:|---:|---:|---|
+
+## What Changed
+
+- Detector change:
+- Tests added:
+- Docs updated:
+
+## Limits
+
+- What this scan does not measure:
+- Known setup failures:
+- Follow-up cohort:
+```
+
+## Current Research Tracks
+
+### 1. GitHub Trending Quality Sweep
+
+Monthly scan of trending open-source repositories by language. The purpose is precision: find noisy rules before users do.
+
+Governance question it answers: which rule classes are noisy in real ecosystems before they reach a customer's CI gate?
+
+Minimum output:
+
+- cohort list and commit SHAs
+- top finding classes
+- false-positive fixes
+- regression tests added
+
+### 2. Agent Output Benchmark
+
+Run the same tasks across AI coding agents, then score the produced repositories with aislop. The purpose is to answer a question developers already ask: which agents leave the least maintainability debt?
+
+Governance question it answers: which agents are safe enough for which repositories?
+
+Minimum output:
+
+- task prompt
+- agent/version
+- clean-room run notes
+- aislop score and rule distribution
+- qualitative code review notes only after the deterministic score
+
+### 3. Benchmark-to-Rule Translation
+
+Read academic or industry benchmarks and translate repeatable structural signals into scanner-shaped rules.
+
+Governance question it answers: which risks are backed by external evidence, not just our opinion?
+
+The SlopCodeBench-derived Python rules are the model:
+
+- identify deterministic pattern
+- avoid judge-only scoring
+- write positive and negative fixtures
+- document rule provenance
+
+### 4. Rule Provenance
+
+Governance question it answers: why did this PR fail, and is the rule that failed it backed by public evidence?
+
+Every first-party AI-slop rule should eventually link to:
+
+- the motivating pattern
+- one public source or benchmark signal
+- the detector strategy
+- examples of legitimate code that should not be flagged
+
+## What Not To Do
+
+- Do not publish leaderboards without pinned versions and a repeatable harness.
+- Do not claim a repository is "bad" because of a single scan. Report rule distributions and examples instead.
+- Do not tune rules only to make one public report look better.
+- Do not use private customer code in public research.
+- Do not mix LLM judgment into scanner output. If human review is used, label it separately.

--- a/editors/vscode/README.md
+++ b/editors/vscode/README.md
@@ -1,0 +1,42 @@
+# aislop for VS Code
+
+Surfaces [aislop](https://github.com/scanaislop/aislop) code-quality findings as
+diagnostics (squiggles) directly in the editor, plus a status-bar score.
+
+This extension does **not** bundle a scanner. It shells out to the `aislop` CLI
+you already have installed and parses its `aislop scan <path> --json` envelope.
+
+## Requirements
+
+Install the CLI globally (or point `aislop.path` at a local binary):
+
+```bash
+npm i -g aislop
+```
+
+## Features
+
+- Scans the workspace on activation and re-scans a file on save.
+- Publishes findings to the `aislop` diagnostic collection with the rule id
+  (`engine/rule`) and message at the reported line/column.
+- Status-bar item showing the latest score out of 100; click it to re-scan.
+- Command **aislop: Scan Workspace** (`aislop.scanWorkspace`).
+- If the CLI is missing, shows a friendly prompt instead of crashing.
+
+## Settings
+
+| Setting             | Default    | Description                          |
+| ------------------- | ---------- | ------------------------------------ |
+| `aislop.path`       | `"aislop"` | Path to the aislop CLI executable.   |
+| `aislop.scanOnSave` | `true`     | Re-scan a file when it is saved.     |
+
+## Develop
+
+```bash
+npm install      # install dev deps (@types/vscode, typescript)
+npm run compile  # tsc -> out/extension.js
+```
+
+Then press `F5` in VS Code to launch an Extension Development Host with the
+extension loaded. The build is fully self-contained: this package has its own
+`package.json` and `tsconfig.json` and is not part of the root aislop build.

--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -1,0 +1,50 @@
+{
+  "name": "aislop-vscode",
+  "displayName": "aislop",
+  "description": "Surface aislop code-quality findings as diagnostics in VS Code by shelling out to your installed aislop CLI.",
+  "version": "0.1.0",
+  "publisher": "scanaislop",
+  "license": "MIT",
+  "engines": {
+    "vscode": "^1.85.0"
+  },
+  "categories": [
+    "Linters"
+  ],
+  "main": "./out/extension.js",
+  "activationEvents": [
+    "onStartupFinished"
+  ],
+  "contributes": {
+    "commands": [
+      {
+        "command": "aislop.scanWorkspace",
+        "title": "aislop: Scan Workspace"
+      }
+    ],
+    "configuration": {
+      "title": "aislop",
+      "properties": {
+        "aislop.path": {
+          "type": "string",
+          "default": "aislop",
+          "description": "Path to the aislop CLI executable."
+        },
+        "aislop.scanOnSave": {
+          "type": "boolean",
+          "default": true,
+          "description": "Re-scan a file when it is saved."
+        }
+      }
+    }
+  },
+  "scripts": {
+    "compile": "tsc -p ./",
+    "watch": "tsc -watch -p ./"
+  },
+  "devDependencies": {
+    "@types/node": "^20.11.0",
+    "@types/vscode": "^1.85.0",
+    "typescript": "^5.4.0"
+  }
+}

--- a/editors/vscode/src/extension.ts
+++ b/editors/vscode/src/extension.ts
@@ -1,0 +1,187 @@
+import { execFile } from "node:child_process";
+import * as vscode from "vscode";
+
+interface AislopDiagnostic {
+	filePath: string;
+	engine: string;
+	rule: string;
+	severity: "error" | "warning" | "info";
+	message: string;
+	line: number;
+	column: number;
+	fixable: boolean;
+}
+
+interface AislopEnvelope {
+	schemaVersion: string;
+	score: number;
+	diagnostics: AislopDiagnostic[];
+	summary: {
+		errors: number;
+		warnings: number;
+		fixable: number;
+		files: number;
+	};
+}
+
+interface ScanOutcome {
+	envelope: AislopEnvelope;
+	stderr: string;
+}
+
+class AislopNotInstalledError extends Error {}
+
+const SEVERITY_MAP: Record<AislopDiagnostic["severity"], vscode.DiagnosticSeverity> = {
+	error: vscode.DiagnosticSeverity.Error,
+	warning: vscode.DiagnosticSeverity.Warning,
+	info: vscode.DiagnosticSeverity.Information,
+};
+
+const toSeverity = (severity: AislopDiagnostic["severity"]): vscode.DiagnosticSeverity =>
+	SEVERITY_MAP[severity] ?? vscode.DiagnosticSeverity.Warning;
+
+const getCliPath = (): string =>
+	vscode.workspace.getConfiguration("aislop").get<string>("path", "aislop");
+
+const isMissingBinary = (error: NodeJS.ErrnoException): boolean =>
+	error.code === "ENOENT" || /not found|not recognized/i.test(error.message);
+
+const runScan = (target: string, cwd: string): Promise<ScanOutcome> =>
+	new Promise((resolve, reject) => {
+		execFile(
+			getCliPath(),
+			["scan", target, "--json"],
+			{ cwd, maxBuffer: 16 * 1024 * 1024 },
+			(error, stdout, stderr) => {
+				if (error && isMissingBinary(error as NodeJS.ErrnoException)) {
+					reject(new AislopNotInstalledError(error.message));
+					return;
+				}
+				if (!stdout.trim()) {
+					reject(new Error(stderr.trim() || (error ? error.message : "aislop produced no output")));
+					return;
+				}
+				try {
+					const envelope = JSON.parse(stdout) as AislopEnvelope;
+					resolve({ envelope, stderr });
+				} catch {
+					reject(new Error("Failed to parse aislop JSON output"));
+				}
+			},
+		);
+	});
+
+const toDiagnostic = (finding: AislopDiagnostic): vscode.Diagnostic => {
+	const line = Math.max(0, finding.line - 1);
+	const column = Math.max(0, finding.column - 1);
+	const range = new vscode.Range(line, column, line, column + 1);
+	const diagnostic = new vscode.Diagnostic(range, finding.message, toSeverity(finding.severity));
+	diagnostic.source = "aislop";
+	diagnostic.code = `${finding.engine}/${finding.rule}`;
+	return diagnostic;
+};
+
+const publishDiagnostics = (
+	collection: vscode.DiagnosticCollection,
+	envelope: AislopEnvelope,
+	scopedFile?: vscode.Uri,
+): void => {
+	if (scopedFile) {
+		collection.set(scopedFile, envelope.diagnostics.map(toDiagnostic));
+		return;
+	}
+	collection.clear();
+	const byFile = new Map<string, vscode.Diagnostic[]>();
+	for (const finding of envelope.diagnostics) {
+		const existing = byFile.get(finding.filePath) ?? [];
+		existing.push(toDiagnostic(finding));
+		byFile.set(finding.filePath, existing);
+	}
+	for (const [filePath, diagnostics] of byFile) {
+		collection.set(vscode.Uri.file(filePath), diagnostics);
+	}
+};
+
+const updateStatusBar = (item: vscode.StatusBarItem, envelope: AislopEnvelope): void => {
+	item.text = `$(shield) aislop ${envelope.score}/100`;
+	item.tooltip = `${envelope.summary.errors} errors, ${envelope.summary.warnings} warnings (${envelope.summary.fixable} fixable)`;
+	item.show();
+};
+
+const reportFailure = (error: unknown, status: vscode.StatusBarItem): void => {
+	if (error instanceof AislopNotInstalledError) {
+		status.text = "$(shield) aislop: not installed";
+		status.tooltip = "Install the aislop CLI: npm i -g aislop";
+		status.show();
+		void vscode.window.showWarningMessage(
+			"aislop CLI not found. Install it with `npm i -g aislop` or set `aislop.path`.",
+		);
+		return;
+	}
+	const message = error instanceof Error ? error.message : String(error);
+	void vscode.window.showErrorMessage(`aislop scan failed: ${message}`);
+};
+
+const scan = async (
+	target: string,
+	cwd: string,
+	collection: vscode.DiagnosticCollection,
+	status: vscode.StatusBarItem,
+	scopedFile?: vscode.Uri,
+): Promise<void> => {
+	try {
+		const { envelope } = await runScan(target, cwd);
+		publishDiagnostics(collection, envelope, scopedFile);
+		updateStatusBar(status, envelope);
+	} catch (error) {
+		reportFailure(error, status);
+	}
+};
+
+const workspaceRoot = (uri?: vscode.Uri): vscode.WorkspaceFolder | undefined => {
+	if (uri) {
+		const folder = vscode.workspace.getWorkspaceFolder(uri);
+		if (folder) {
+			return folder;
+		}
+	}
+	return vscode.workspace.workspaceFolders?.[0];
+};
+
+export const activate = (context: vscode.ExtensionContext): void => {
+	const collection = vscode.languages.createDiagnosticCollection("aislop");
+	const status = vscode.window.createStatusBarItem(vscode.StatusBarAlignment.Left, 0);
+	status.command = "aislop.scanWorkspace";
+	context.subscriptions.push(collection, status);
+
+	const scanWorkspace = (): void => {
+		const folder = workspaceRoot();
+		if (!folder) {
+			void vscode.window.showInformationMessage("aislop: open a folder to scan.");
+			return;
+		}
+		void scan(folder.uri.fsPath, folder.uri.fsPath, collection, status);
+	};
+
+	const scanDocument = (document: vscode.TextDocument): void => {
+		if (document.uri.scheme !== "file") {
+			return;
+		}
+		const folder = workspaceRoot(document.uri);
+		const cwd = folder ? folder.uri.fsPath : document.uri.fsPath;
+		void scan(document.uri.fsPath, cwd, collection, status, document.uri);
+	};
+
+	context.subscriptions.push(
+		vscode.commands.registerCommand("aislop.scanWorkspace", scanWorkspace),
+		vscode.workspace.onDidSaveTextDocument((document) => {
+			if (vscode.workspace.getConfiguration("aislop").get<boolean>("scanOnSave", true)) {
+				scanDocument(document);
+			}
+		}),
+	);
+
+	scanWorkspace();
+};
+
+export const deactivate = (): void => {};

--- a/editors/vscode/tsconfig.json
+++ b/editors/vscode/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "Node16",
+    "moduleResolution": "Node16",
+    "lib": ["ES2022"],
+    "outDir": "out",
+    "rootDir": "src",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "sourceMap": true
+  },
+  "include": ["src"],
+  "exclude": ["node_modules", "out"]
+}

--- a/knip.json
+++ b/knip.json
@@ -1,5 +1,8 @@
 {
 	"$schema": "https://unpkg.com/knip@5/schema.json",
+	"ignore": [
+		"editors/**"
+	],
 	"ignoreDependencies": [
 		"@biomejs/biome",
 		"oxlint",

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "build": "rm -rf dist && NODE_ENV=production tsdown",
     "postinstall": "node scripts/postinstall-tools.mjs",
     "typecheck": "tsc --noEmit",
+    "gen:schema": "node --experimental-strip-types scripts/gen-config-schema.mjs",
     "test": "pnpm build && vitest run",
     "scan": "pnpm build && node dist/cli.js scan .",
     "scan:exclude": "pnpm build && node dist/cli.js scan . --exclude .idea --exclude .gitnore --exclude node_modules",

--- a/schema/aislop.config.schema.json
+++ b/schema/aislop.config.schema.json
@@ -1,0 +1,241 @@
+{
+	"$schema": "https://json-schema.org/draft/2020-12/schema",
+	"type": "object",
+	"properties": {
+		"version": {
+			"default": 1,
+			"type": "number"
+		},
+		"engines": {
+			"default": {
+				"format": true,
+				"lint": true,
+				"code-quality": true,
+				"ai-slop": true,
+				"architecture": false,
+				"security": true
+			},
+			"type": "object",
+			"properties": {
+				"format": {
+					"default": true,
+					"type": "boolean"
+				},
+				"lint": {
+					"default": true,
+					"type": "boolean"
+				},
+				"code-quality": {
+					"default": true,
+					"type": "boolean"
+				},
+				"ai-slop": {
+					"default": true,
+					"type": "boolean"
+				},
+				"architecture": {
+					"default": false,
+					"type": "boolean"
+				},
+				"security": {
+					"default": true,
+					"type": "boolean"
+				}
+			}
+		},
+		"quality": {
+			"default": {
+				"maxFunctionLoc": 80,
+				"maxFileLoc": 400,
+				"maxNesting": 5,
+				"maxParams": 6
+			},
+			"type": "object",
+			"properties": {
+				"maxFunctionLoc": {
+					"default": 80,
+					"type": "number",
+					"exclusiveMinimum": 0
+				},
+				"maxFileLoc": {
+					"default": 400,
+					"type": "number",
+					"exclusiveMinimum": 0
+				},
+				"maxNesting": {
+					"default": 5,
+					"type": "number",
+					"exclusiveMinimum": 0
+				},
+				"maxParams": {
+					"default": 6,
+					"type": "number",
+					"exclusiveMinimum": 0
+				}
+			}
+		},
+		"lint": {
+			"default": {
+				"typecheck": false
+			},
+			"type": "object",
+			"properties": {
+				"typecheck": {
+					"default": false,
+					"type": "boolean"
+				}
+			}
+		},
+		"security": {
+			"default": {
+				"audit": true,
+				"auditTimeout": 25000
+			},
+			"type": "object",
+			"properties": {
+				"audit": {
+					"default": true,
+					"type": "boolean"
+				},
+				"auditTimeout": {
+					"default": 25000,
+					"type": "number",
+					"exclusiveMinimum": 0
+				}
+			}
+		},
+		"scoring": {
+			"default": {
+				"weights": {
+					"format": 0.3,
+					"lint": 0.6,
+					"code-quality": 0.8,
+					"ai-slop": 2.5,
+					"architecture": 1,
+					"security": 1.5
+				},
+				"thresholds": {
+					"good": 75,
+					"ok": 50
+				},
+				"smoothing": 20
+			},
+			"type": "object",
+			"properties": {
+				"weights": {
+					"default": {
+						"format": 0.3,
+						"lint": 0.6,
+						"code-quality": 0.8,
+						"ai-slop": 2.5,
+						"architecture": 1,
+						"security": 1.5
+					},
+					"type": "object",
+					"propertyNames": {
+						"type": "string"
+					},
+					"additionalProperties": {
+						"type": "number"
+					}
+				},
+				"thresholds": {
+					"default": {
+						"good": 75,
+						"ok": 50
+					},
+					"type": "object",
+					"properties": {
+						"good": {
+							"default": 75,
+							"type": "number"
+						},
+						"ok": {
+							"default": 50,
+							"type": "number"
+						}
+					}
+				},
+				"smoothing": {
+					"default": 20,
+					"type": "number",
+					"minimum": 0
+				}
+			}
+		},
+		"ci": {
+			"default": {
+				"failBelow": 70,
+				"format": "json"
+			},
+			"type": "object",
+			"properties": {
+				"failBelow": {
+					"default": 70,
+					"type": "number"
+				},
+				"format": {
+					"default": "json",
+					"type": "string",
+					"enum": [
+						"json"
+					]
+				}
+			}
+		},
+		"telemetry": {
+			"default": {
+				"enabled": true
+			},
+			"type": "object",
+			"properties": {
+				"enabled": {
+					"default": true,
+					"type": "boolean"
+				}
+			}
+		},
+		"rules": {
+			"default": {},
+			"type": "object",
+			"propertyNames": {
+				"type": "string"
+			},
+			"additionalProperties": {
+				"type": "string",
+				"enum": [
+					"error",
+					"warning",
+					"off"
+				]
+			}
+		},
+		"exclude": {
+			"default": [
+				"node_modules",
+				".git",
+				"dist",
+				"build",
+				"coverage"
+			],
+			"type": "array",
+			"items": {
+				"type": "string"
+			}
+		},
+		"include": {
+			"default": [],
+			"type": "array",
+			"items": {
+				"type": "string"
+			}
+		},
+		"extends": {
+			"type": "string",
+			"description": "Path to a parent .aislop config to extend."
+		}
+	},
+	"$id": "https://scanaislop.com/schema/aislop.config.schema.json",
+	"title": "aislop configuration (.aislop/config.yml)",
+	"description": "Configuration schema for the aislop code-quality CLI."
+}

--- a/scripts/gen-config-schema.mjs
+++ b/scripts/gen-config-schema.mjs
@@ -1,0 +1,35 @@
+#!/usr/bin/env node
+import { writeFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { z } from "zod/v4";
+import { AislopConfigSchema } from "../src/config/schema.ts";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const outPath = resolve(here, "..", "schema", "aislop.config.schema.json");
+
+// Strip `required`/`additionalProperties:false` so partial user configs (every
+// key has a default) validate, and allow the loader-handled `extends` key.
+const relax = (node) => {
+	if (!node || typeof node !== "object") return;
+	if (Array.isArray(node)) {
+		for (const item of node) relax(item);
+		return;
+	}
+	delete node.required;
+	if (node.additionalProperties === false) delete node.additionalProperties;
+	for (const value of Object.values(node)) relax(value);
+};
+
+const jsonSchema = z.toJSONSchema(AislopConfigSchema, { target: "draft-2020-12" });
+relax(jsonSchema);
+jsonSchema.$id = "https://scanaislop.com/schema/aislop.config.schema.json";
+jsonSchema.title = "aislop configuration (.aislop/config.yml)";
+jsonSchema.description = "Configuration schema for the aislop code-quality CLI.";
+jsonSchema.properties.extends = {
+	type: "string",
+	description: "Path to a parent .aislop config to extend.",
+};
+
+writeFileSync(outPath, `${JSON.stringify(jsonSchema, null, "\t")}\n`);
+process.stdout.write(`Wrote ${outPath}\n`);

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -8,6 +8,7 @@ import { initCommand } from "./commands/init.js";
 import { interactiveCommand } from "./commands/interactive.js";
 import { rulesCommand } from "./commands/rules.js";
 import { scanCommand } from "./commands/scan.js";
+import { trendCommand } from "./commands/trend.js";
 import { loadConfig } from "./config/index.js";
 import {
 	ensureInstallId,
@@ -38,6 +39,8 @@ interface ScanFlags {
 	staged?: boolean;
 	verbose?: boolean;
 	json?: boolean;
+	sarif?: boolean;
+	format?: string;
 	exclude?: string[];
 	include?: string[];
 }
@@ -50,6 +53,10 @@ const commaSeparatedParser = (value: string, previous: string[] = []): string[] 
 	return [...previous, ...parts];
 };
 
+const wantsSarif = (flags: ScanFlags): boolean => Boolean(flags.sarif) || flags.format === "sarif";
+
+const wantsJson = (flags: ScanFlags): boolean => Boolean(flags.json) || flags.format === "json";
+
 const runScan = async (directory: string, flags: ScanFlags): Promise<void> => {
 	const config = loadConfig(directory);
 	const finalConfig = {
@@ -57,11 +64,13 @@ const runScan = async (directory: string, flags: ScanFlags): Promise<void> => {
 		exclude: [...(config.exclude ?? []), ...(flags.exclude ?? [])],
 		include: [...(config.include ?? []), ...(flags.include ?? [])],
 	};
+	const sarif = wantsSarif(flags);
 	const { exitCode } = await scanCommand(directory, finalConfig, {
 		changes: Boolean(flags.changes),
 		staged: Boolean(flags.staged),
 		verbose: Boolean(flags.verbose),
-		json: Boolean(flags.json),
+		json: !sarif && wantsJson(flags),
+		sarif,
 		exclude: flags.exclude,
 		include: flags.include,
 	});
@@ -76,6 +85,8 @@ const noFlagsPassed = (flags: ScanFlags): boolean =>
 	!flags.staged &&
 	!flags.verbose &&
 	!flags.json &&
+	!flags.sarif &&
+	!flags.format &&
 	!(flags.exclude && flags.exclude.length > 0) &&
 	!(flags.include && flags.include.length > 0);
 
@@ -88,6 +99,8 @@ const program = new Command()
 	.option("--staged", "only scan staged files")
 	.option("-d, --verbose", "show file details per rule")
 	.option("--json", "output JSON instead of terminal UI")
+	.option("--sarif", "output SARIF 2.1.0 (for GitHub code scanning)")
+	.option("--format <format>", "output format: json or sarif")
 	.option(
 		"--exclude <patterns>",
 		"comma-separated or repeatable list of paths and files to exclude",
@@ -122,6 +135,7 @@ ${style(theme, "dim", "Commands:")}
   npx aislop doctor [dir]    Check installed tools
   npx aislop ci [dir]        CI-friendly JSON output
   npx aislop rules [dir]     List all rules
+  npx aislop trend [dir]     Show score history trend
 
 ${style(theme, "dim", "Examples:")}
   npx aislop                 Interactive menu
@@ -135,6 +149,8 @@ ${style(theme, "dim", "Examples:")}
   npx aislop fix --cursor    Open Cursor + copy prompt to clipboard
   npx aislop fix -p          Print a prompt to paste into any coding agent
   npx aislop ci              JSON output for CI pipelines
+  npx aislop scan --sarif    SARIF 2.1.0 for GitHub code scanning
+  npx aislop trend           Show score history over time
   npx aislop scan --exclude node_modules
   npx aislop scan --exclude node_modules,dist,file.txt
   npx aislop scan --exclude node_modules --exclude dist --exclude **/*.ts
@@ -149,6 +165,8 @@ program
 	.option("--staged", "only scan staged files")
 	.option("-d, --verbose", "show file details per rule")
 	.option("--json", "output JSON")
+	.option("--sarif", "output SARIF 2.1.0 (for GitHub code scanning)")
+	.option("--format <format>", "output format: json or sarif")
 	.option(
 		"--exclude <patterns>",
 		"comma-separated or repeatable list of paths and files to exclude",
@@ -242,11 +260,18 @@ program
 	.command("ci [directory]")
 	.description("CI-friendly JSON output with exit codes")
 	.option("--human", "render the human-friendly scan design instead of JSON")
+	.option("--sarif", "output SARIF 2.1.0 (for GitHub code scanning)")
+	.option("--format <format>", "output format: json or sarif")
 	.action(async (directory = ".", _flags, command) => {
-		const flags = command.optsWithGlobals() as { human?: boolean };
+		const flags = command.optsWithGlobals() as {
+			human?: boolean;
+			sarif?: boolean;
+			format?: string;
+		};
 		const config = loadConfig(directory);
 		const { exitCode } = await ciCommand(directory, config, {
 			human: Boolean(flags.human),
+			sarif: Boolean(flags.sarif) || flags.format === "sarif",
 		});
 		if (exitCode !== 0) {
 			await flushTelemetry();
@@ -297,6 +322,21 @@ program
 			process.stderr.write(`${message}\n`);
 			process.exit(1);
 		}
+	});
+
+program
+	.command("trend [directory]")
+	.description("Show score history trend from .aislop/history.jsonl")
+	.option("--limit <n>", "number of recent runs to show", (v) => Number.parseInt(v, 10))
+	.action(async (directory = ".", _flags, command) => {
+		const flags = command.optsWithGlobals() as { limit?: number };
+		await withCommandLifecycle(
+			{ command: "trend", config: loadConfig(directory).telemetry },
+			async () => {
+				trendCommand(directory, flags.limit);
+				return { exitCode: 0 };
+			},
+		);
 	});
 
 registerHookCommand(program);

--- a/src/commands/ci.ts
+++ b/src/commands/ci.ts
@@ -4,6 +4,7 @@ import { scanCommand } from "./scan.js";
 
 interface CiOptions {
 	human?: boolean;
+	sarif?: boolean;
 }
 
 export const ciCommand = async (
@@ -16,7 +17,8 @@ export const ciCommand = async (
 			changes: false,
 			staged: false,
 			verbose: false,
-			json: !options.human,
+			json: !options.human && !options.sarif,
+			sarif: options.sarif,
 			command: "ci",
 		});
 	} catch (error) {

--- a/src/commands/scan.ts
+++ b/src/commands/scan.ts
@@ -7,6 +7,7 @@ import type { Diagnostic, EngineConfig, EngineName, EngineResult } from "../engi
 import { ENGINE_INFO, getEngineLabel } from "../output/engine-info.js";
 import { printEngineStatus, renderDiagnostics } from "../output/terminal.js";
 import { calculateScore } from "../scoring/index.js";
+import { applyRuleSeverities } from "../scoring/rule-severity.js";
 import { renderHeader } from "../ui/header.js";
 import { detectInvocation } from "../ui/invocation.js";
 import { type GridRow, type GridRowOutcome, LiveGrid } from "../ui/live-grid.js";
@@ -22,7 +23,9 @@ import { createSymbols } from "../ui/symbols.js";
 import { createTheme } from "../ui/theme.js";
 import { discoverProject } from "../utils/discover.js";
 import { getChangedFiles, getStagedFiles } from "../utils/git.js";
+import { appendHistory } from "../utils/history.js";
 import { filterProjectFiles, listProjectFiles } from "../utils/source-files.js";
+import { isCiEnv } from "../telemetry/env.js";
 import { type EngineCounts, withCommandLifecycle } from "../telemetry/index.js";
 import { APP_VERSION } from "../version.js";
 
@@ -31,6 +34,7 @@ interface ScanOptions {
 	staged: boolean;
 	verbose: boolean;
 	json: boolean;
+	sarif?: boolean;
 	showHeader?: boolean;
 	printBrand?: boolean;
 	exclude?: string[];
@@ -38,6 +42,10 @@ interface ScanOptions {
 	/** Used for telemetry to distinguish scan vs ci invocation */
 	command?: "scan" | "ci";
 }
+
+// SARIF and JSON are machine outputs: suppress all human chrome on stdout.
+const isMachineOutput = (options: ScanOptions): boolean =>
+	Boolean(options.json) || Boolean(options.sarif);
 
 const shouldUseSpinner = (): boolean =>
 	Boolean(process.stderr.isTTY) && process.env.CI !== "true" && process.env.CI !== "1";
@@ -225,23 +233,24 @@ const runScanBody = async (
 ) => {
 	const startTime = performance.now();
 	const showHeader = options.showHeader !== false;
-	const useLiveProgress = !options.json && shouldUseSpinner();
+	const machineOutput = isMachineOutput(options);
+	const useLiveProgress = !machineOutput && shouldUseSpinner();
 
 	let files: string[] | undefined;
 	if (options.staged) {
 		files = filterProjectFiles(resolvedDir, getStagedFiles(resolvedDir), [], config.exclude);
-		if (!options.json) {
+		if (!machineOutput) {
 			log.muted(`Scope: ${files.length} staged file(s)`);
 		}
 	} else if (options.changes) {
 		files = filterProjectFiles(resolvedDir, getChangedFiles(resolvedDir), [], config.exclude);
-		if (!options.json) {
+		if (!machineOutput) {
 			log.muted(`Scope: ${files.length} changed file(s)`);
 		}
 	} else {
 		const allFiles = listProjectFiles(resolvedDir);
 		files = filterProjectFiles(resolvedDir, allFiles, [], config.exclude);
-		if (!options.json) {
+		if (!machineOutput) {
 			log.muted(`Scope: ${files.length} file(s) after exclusions`);
 		}
 	}
@@ -266,7 +275,7 @@ const runScanBody = async (
 
 	progressRenderer?.start();
 
-	const results = await runEngines(
+	const rawResults = await runEngines(
 		{
 			rootDirectory: resolvedDir,
 			languages: projectInfo.languages,
@@ -301,12 +310,17 @@ const runScanBody = async (
 					elapsedMs: result.elapsed,
 				});
 			}
-			if (!options.json && !progressRenderer) {
+			if (!machineOutput && !progressRenderer) {
 				printEngineStatus(result);
 			}
 		},
 	);
 	progressRenderer?.stop();
+
+	const results = rawResults.map((result) => ({
+		...result,
+		diagnostics: applyRuleSeverities(result.diagnostics, config.rules),
+	}));
 
 	const allDiagnostics = results.flatMap((r) => r.diagnostics);
 	const elapsedMs = performance.now() - startTime;
@@ -338,11 +352,30 @@ const runScanBody = async (
 		engineTimings,
 	};
 
+	if (options.sarif) {
+		const { buildSarifLog } = await import("../output/sarif.js");
+		console.log(JSON.stringify(buildSarifLog(results), null, 2));
+		return completion;
+	}
+
 	if (options.json) {
 		const { buildJsonOutput } = await import("../output/json.js");
 		const jsonOut = buildJsonOutput(results, scoreResult, projectInfo.sourceFileCount, elapsedMs);
 		console.log(JSON.stringify(jsonOut, null, 2));
 		return completion;
+	}
+
+	// Only record full-project human scans: scoped (--staged/--changes) scores
+	// aren't comparable across runs, and CI runs would pollute local trends.
+	const isFullScopeScan = !options.staged && !options.changes && options.command !== "ci";
+	if (isFullScopeScan && !isCiEnv()) {
+		appendHistory({
+			directory: resolvedDir,
+			score: scoreResult.score,
+			errors: completion.errorCount,
+			warnings: completion.warningCount,
+			files: projectInfo.sourceFileCount,
+		});
 	}
 
 	const projectName = projectInfo.projectName ?? "project";

--- a/src/commands/trend.ts
+++ b/src/commands/trend.ts
@@ -1,0 +1,98 @@
+import { renderHeader } from "../ui/header.js";
+import { renderHintLine } from "../ui/logger.js";
+import { style, theme } from "../ui/theme.js";
+import { padEnd } from "../ui/width.js";
+import { type HistoryRecord, readHistory } from "../utils/history.js";
+import { APP_VERSION } from "../version.js";
+
+const SPARK_TICKS = ["▁", "▂", "▃", "▄", "▅", "▆", "▇", "█"];
+const DEFAULT_LIMIT = 20;
+
+export const renderSparkline = (scores: number[]): string => {
+	if (scores.length === 0) return "";
+	const min = Math.min(...scores);
+	const max = Math.max(...scores);
+	const span = max - min;
+	return scores
+		.map((score) => {
+			if (span === 0) return SPARK_TICKS[SPARK_TICKS.length - 1];
+			const ratio = (score - min) / span;
+			const index = Math.round(ratio * (SPARK_TICKS.length - 1));
+			return SPARK_TICKS[index];
+		})
+		.join("");
+};
+
+const formatDate = (timestamp: string): string => {
+	const date = new Date(timestamp);
+	if (Number.isNaN(date.getTime())) return timestamp;
+	return date.toISOString().slice(0, 16).replace("T", " ");
+};
+
+const delta = (current: number, previous: number | undefined): string => {
+	if (previous === undefined) return "";
+	const diff = current - previous;
+	if (diff > 0) return style(theme, "success", `+${diff}`);
+	if (diff < 0) return style(theme, "danger", `${diff}`);
+	return style(theme, "muted", "0");
+};
+
+interface BuildTrendRenderInput {
+	records: HistoryRecord[];
+	limit?: number;
+	printBrand?: boolean;
+}
+
+export const buildTrendRender = (input: BuildTrendRenderInput): string => {
+	const header = renderHeader({
+		version: APP_VERSION,
+		command: "trend",
+		context: [],
+		brand: input.printBrand !== false,
+	});
+
+	if (input.records.length === 0) {
+		return `${header}\n  ${style(
+			theme,
+			"muted",
+			"No score history yet. Run a scan to start tracking trends.",
+		)}\n`;
+	}
+
+	const limit = input.limit ?? DEFAULT_LIMIT;
+	const recent = input.records.slice(-limit);
+	const scores = recent.map((r) => r.score);
+
+	const lines: string[] = [header];
+	lines.push(
+		`  ${style(theme, "dim", padEnd("Date", 18))}${style(theme, "dim", padEnd("Score", 8))}${style(
+			theme,
+			"dim",
+			padEnd("Δ", 6),
+		)}${style(theme, "dim", padEnd("Err", 6))}${style(theme, "dim", "Warn")}`,
+	);
+	recent.forEach((record, index) => {
+		const previous = index > 0 ? recent[index - 1]?.score : undefined;
+		lines.push(
+			`  ${padEnd(formatDate(record.timestamp), 18)}${padEnd(String(record.score), 8)}${padEnd(
+				delta(record.score, previous),
+				6,
+			)}${padEnd(String(record.errors), 6)}${record.warnings}`,
+		);
+	});
+
+	const latest = recent[recent.length - 1];
+	lines.push("");
+	lines.push(`  ${style(theme, "accent", renderSparkline(scores))}`);
+	lines.push(
+		`  ${style(theme, "muted", `${recent.length} run(s), latest score ${latest?.score}`)}`,
+	);
+	lines.push(renderHintLine("Run aislop scan to add a new data point").trimEnd());
+
+	return `${lines.join("\n")}\n`;
+};
+
+export const trendCommand = (directory: string, limit?: number): void => {
+	const records = readHistory(directory);
+	process.stdout.write(buildTrendRender({ records, limit }));
+};

--- a/src/config/defaults.ts
+++ b/src/config/defaults.ts
@@ -47,6 +47,7 @@ export const DEFAULT_CONFIG: AislopConfig = {
 	telemetry: {
 		enabled: true,
 	},
+	rules: {},
 };
 
 export const GITHUB_WORKFLOW_DIR = ".github/workflows";

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -57,6 +57,10 @@ const TelemetrySchema = z.object({
 	enabled: z.boolean().default(true),
 });
 
+const RuleSeverityOverride = z.enum(["error", "warning", "off"]);
+
+const RulesSchema = z.record(z.string(), RuleSeverityOverride).default(() => ({}));
+
 const AislopConfigSchema = z.object({
 	version: z.number().default(1),
 	engines: EnginesSchema.default(() => ({
@@ -95,9 +99,14 @@ const AislopConfigSchema = z.object({
 	telemetry: TelemetrySchema.default(() => ({
 		enabled: true,
 	})),
+	rules: RulesSchema,
 	exclude: z.array(z.string()).default(() => ["node_modules", ".git", "dist", "build", "coverage"]),
 	include: z.array(z.string()).default(() => []),
 });
+
+export type RuleSeverity = z.infer<typeof RuleSeverityOverride>;
+
+export { AislopConfigSchema };
 
 export type AislopConfig = z.infer<typeof AislopConfigSchema>;
 

--- a/src/output/sarif.ts
+++ b/src/output/sarif.ts
@@ -1,0 +1,110 @@
+import path from "node:path";
+import type { Diagnostic, EngineResult, Severity } from "../engines/types.js";
+import { APP_VERSION } from "../version.js";
+
+const SARIF_VERSION = "2.1.0";
+const SARIF_SCHEMA =
+	"https://raw.githubusercontent.com/oasis-tcs/sarif-spec/master/Schemata/sarif-schema-2.1.0.json";
+
+type SarifLevel = "error" | "warning" | "note";
+
+interface SarifReportingDescriptor {
+	id: string;
+	name?: string;
+	shortDescription?: { text: string };
+	helpUri?: string;
+	help?: { text: string };
+}
+
+interface SarifResult {
+	ruleId: string;
+	ruleIndex: number;
+	level: SarifLevel;
+	message: { text: string };
+	locations: Array<{
+		physicalLocation: {
+			artifactLocation: { uri: string };
+			region: { startLine: number; startColumn: number };
+		};
+	}>;
+}
+
+interface SarifLog {
+	$schema: string;
+	version: string;
+	runs: Array<{
+		tool: {
+			driver: {
+				name: string;
+				version: string;
+				informationUri: string;
+				rules: SarifReportingDescriptor[];
+			};
+		};
+		results: SarifResult[];
+	}>;
+}
+
+const levelFromSeverity = (severity: Severity): SarifLevel => {
+	if (severity === "error") return "error";
+	if (severity === "warning") return "warning";
+	return "note";
+};
+
+// SARIF regions are 1-based; clamp engine output that may emit 0 to keep validators happy.
+const oneBased = (value: number): number => (value >= 1 ? value : 1);
+
+const toUri = (filePath: string): string => filePath.split(path.sep).join("/");
+
+const buildRules = (diagnostics: Diagnostic[]): SarifReportingDescriptor[] => {
+	const byId = new Map<string, SarifReportingDescriptor>();
+	for (const d of diagnostics) {
+		if (byId.has(d.rule)) continue;
+		byId.set(d.rule, {
+			id: d.rule,
+			name: d.rule,
+			shortDescription: { text: d.message },
+			help: { text: d.help || d.message },
+		});
+	}
+	return [...byId.values()];
+};
+
+export const buildSarifLog = (results: EngineResult[]): SarifLog => {
+	const diagnostics = results.flatMap((r) => r.diagnostics);
+	const rules = buildRules(diagnostics);
+	const ruleIndex = new Map(rules.map((rule, index) => [rule.id, index]));
+
+	const sarifResults: SarifResult[] = diagnostics.map((d) => ({
+		ruleId: d.rule,
+		ruleIndex: ruleIndex.get(d.rule) ?? 0,
+		level: levelFromSeverity(d.severity),
+		message: { text: d.message },
+		locations: [
+			{
+				physicalLocation: {
+					artifactLocation: { uri: toUri(d.filePath) },
+					region: { startLine: oneBased(d.line), startColumn: oneBased(d.column) },
+				},
+			},
+		],
+	}));
+
+	return {
+		$schema: SARIF_SCHEMA,
+		version: SARIF_VERSION,
+		runs: [
+			{
+				tool: {
+					driver: {
+						name: "aislop",
+						version: APP_VERSION,
+						informationUri: "https://github.com/scanaislop/aislop",
+						rules,
+					},
+				},
+				results: sarifResults,
+			},
+		],
+	};
+};

--- a/src/scoring/rule-severity.ts
+++ b/src/scoring/rule-severity.ts
@@ -1,0 +1,27 @@
+import type { RuleSeverity } from "../config/schema.js";
+import type { Diagnostic } from "../engines/types.js";
+
+/**
+ * Apply per-rule severity overrides from config: "off" drops the diagnostic,
+ * "error"/"warning" rewrite its severity before scoring and rendering.
+ */
+export const applyRuleSeverities = (
+	diagnostics: Diagnostic[],
+	overrides: Record<string, RuleSeverity>,
+): Diagnostic[] => {
+	if (Object.keys(overrides).length === 0) return diagnostics;
+
+	const result: Diagnostic[] = [];
+	for (const diagnostic of diagnostics) {
+		const override = overrides[diagnostic.rule];
+		if (!override) {
+			result.push(diagnostic);
+			continue;
+		}
+		if (override === "off") continue;
+		result.push(
+			override === diagnostic.severity ? diagnostic : { ...diagnostic, severity: override },
+		);
+	}
+	return result;
+};

--- a/src/telemetry/events.ts
+++ b/src/telemetry/events.ts
@@ -9,6 +9,7 @@ export type CommandName =
 	| "doctor"
 	| "rules"
 	| "badge"
+	| "trend"
 	| "hook_install"
 	| "hook_uninstall"
 	| "hook_status"

--- a/src/utils/history.ts
+++ b/src/utils/history.ts
@@ -1,0 +1,84 @@
+import fs from "node:fs";
+import path from "node:path";
+import { CONFIG_DIR } from "../config/index.js";
+import { APP_VERSION } from "../version.js";
+
+const HISTORY_FILE = "history.jsonl";
+
+export interface HistoryRecord {
+	timestamp: string;
+	score: number;
+	errors: number;
+	warnings: number;
+	files: number;
+	cliVersion: string;
+}
+
+const isHistoryDisabled = (env: NodeJS.ProcessEnv = process.env): boolean =>
+	env.AISLOP_NO_HISTORY === "1";
+
+const historyPath = (directory: string): string =>
+	path.join(path.resolve(directory), CONFIG_DIR, HISTORY_FILE);
+
+interface AppendHistoryInput {
+	directory: string;
+	score: number;
+	errors: number;
+	warnings: number;
+	files: number;
+}
+
+/**
+ * Append a compact scan record to .aislop/history.jsonl. Best-effort: never
+ * throws, so a read-only checkout or missing config dir can't break a scan.
+ */
+export const appendHistory = (input: AppendHistoryInput): void => {
+	if (isHistoryDisabled()) return;
+	const configDir = path.join(path.resolve(input.directory), CONFIG_DIR);
+	if (!fs.existsSync(configDir)) return;
+
+	const record: HistoryRecord = {
+		timestamp: new Date().toISOString(),
+		score: input.score,
+		errors: input.errors,
+		warnings: input.warnings,
+		files: input.files,
+		cliVersion: APP_VERSION,
+	};
+	try {
+		fs.appendFileSync(historyPath(input.directory), `${JSON.stringify(record)}\n`);
+	} catch {
+		// History is a convenience side effect; a failed write must not fail the scan.
+	}
+};
+
+const isHistoryRecord = (value: unknown): value is HistoryRecord => {
+	if (!value || typeof value !== "object") return false;
+	const record = value as Record<string, unknown>;
+	return (
+		typeof record.timestamp === "string" &&
+		typeof record.score === "number" &&
+		typeof record.errors === "number" &&
+		typeof record.warnings === "number" &&
+		typeof record.files === "number" &&
+		typeof record.cliVersion === "string"
+	);
+};
+
+export const readHistory = (directory: string): HistoryRecord[] => {
+	const file = historyPath(directory);
+	if (!fs.existsSync(file)) return [];
+
+	const records: HistoryRecord[] = [];
+	for (const line of fs.readFileSync(file, "utf8").split("\n")) {
+		const trimmed = line.trim();
+		if (!trimmed) continue;
+		try {
+			const parsed: unknown = JSON.parse(trimmed);
+			if (isHistoryRecord(parsed)) records.push(parsed);
+		} catch {
+			// Skip malformed lines rather than aborting the whole history read.
+		}
+	}
+	return records;
+};

--- a/tests/commands/trend.test.ts
+++ b/tests/commands/trend.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from "vitest";
+import { buildTrendRender, renderSparkline } from "../../src/commands/trend.js";
+import type { HistoryRecord } from "../../src/utils/history.js";
+
+const createRecord = (overrides: Partial<HistoryRecord> = {}): HistoryRecord => ({
+	timestamp: "2026-05-29T10:00:00.000Z",
+	score: 90,
+	errors: 0,
+	warnings: 2,
+	files: 50,
+	cliVersion: "0.9.4",
+	...overrides,
+});
+
+// Strip ANSI so assertions are color-mode independent.
+const ANSI_RE = new RegExp(String.raw`\x1B\[[0-9;]*m`, "g");
+const plain = (s: string): string => s.replace(ANSI_RE, "");
+
+describe("renderSparkline", () => {
+	it("returns empty string for no scores", () => {
+		expect(renderSparkline([])).toBe("");
+	});
+
+	it("maps a flat series to the top tick", () => {
+		expect(renderSparkline([80, 80, 80])).toBe("███");
+	});
+
+	it("maps low and high scores to low and high ticks", () => {
+		const spark = renderSparkline([10, 100]);
+		expect(spark[0]).toBe("▁");
+		expect(spark[1]).toBe("█");
+	});
+});
+
+describe("buildTrendRender", () => {
+	it("shows an empty-state message when there is no history", () => {
+		const output = plain(buildTrendRender({ records: [], printBrand: false }));
+		expect(output).toContain("No score history yet");
+	});
+
+	it("renders a table row and sparkline for recorded scans", () => {
+		const records = [
+			createRecord({ score: 70 }),
+			createRecord({ score: 85, timestamp: "2026-05-29T11:00:00.000Z" }),
+		];
+		const output = plain(buildTrendRender({ records, printBrand: false }));
+		expect(output).toContain("70");
+		expect(output).toContain("85");
+		expect(output).toContain("+15");
+		expect(output).toContain("2 run(s), latest score 85");
+	});
+
+	it("respects the limit by keeping only the most recent runs", () => {
+		const records = Array.from({ length: 30 }, (_, i) => createRecord({ score: i }));
+		const output = plain(buildTrendRender({ records, limit: 5, printBrand: false }));
+		expect(output).toContain("5 run(s), latest score 29");
+	});
+});

--- a/tests/output/sarif.test.ts
+++ b/tests/output/sarif.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from "vitest";
+import type { Diagnostic, EngineResult } from "../../src/engines/types.js";
+import { buildSarifLog } from "../../src/output/sarif.js";
+
+const createDiagnostic = (overrides: Partial<Diagnostic> = {}): Diagnostic => ({
+	filePath: "src/example.ts",
+	engine: "ai-slop",
+	rule: "ai-slop/narrative-comment",
+	severity: "warning",
+	message: "Narrative comment",
+	help: "Remove the comment",
+	line: 12,
+	column: 3,
+	category: "comments",
+	fixable: true,
+	...overrides,
+});
+
+const createResult = (diagnostics: Diagnostic[]): EngineResult => ({
+	engine: "ai-slop",
+	diagnostics,
+	elapsed: 1,
+	skipped: false,
+});
+
+describe("buildSarifLog", () => {
+	it("produces a valid SARIF 2.1.0 skeleton with the aislop driver", () => {
+		const log = buildSarifLog([createResult([createDiagnostic()])]);
+
+		expect(log.version).toBe("2.1.0");
+		expect(log.runs).toHaveLength(1);
+		expect(log.runs[0]?.tool.driver.name).toBe("aislop");
+	});
+
+	it("maps severity to SARIF level", () => {
+		const log = buildSarifLog([
+			createResult([
+				createDiagnostic({ severity: "error", rule: "security/hardcoded-secret" }),
+				createDiagnostic({ severity: "warning", rule: "ai-slop/narrative-comment" }),
+				createDiagnostic({ severity: "info", rule: "code-quality/unused-declaration" }),
+			]),
+		]);
+
+		const levels = log.runs[0]?.results.map((r) => r.level);
+		expect(levels).toEqual(["error", "warning", "note"]);
+	});
+
+	it("dedupes rules and links results via ruleIndex", () => {
+		const log = buildSarifLog([
+			createResult([
+				createDiagnostic({ line: 1 }),
+				createDiagnostic({ line: 2 }),
+				createDiagnostic({ rule: "security/hardcoded-secret", severity: "error" }),
+			]),
+		]);
+
+		const rules = log.runs[0]?.tool.driver.rules ?? [];
+		expect(rules.map((r) => r.id)).toEqual([
+			"ai-slop/narrative-comment",
+			"security/hardcoded-secret",
+		]);
+		expect(log.runs[0]?.results[2]?.ruleIndex).toBe(1);
+	});
+
+	it("emits a 1-based physical location", () => {
+		const log = buildSarifLog([
+			createResult([createDiagnostic({ filePath: "src/a/b.ts", line: 0, column: 0 })]),
+		]);
+
+		const region = log.runs[0]?.results[0]?.locations[0]?.physicalLocation.region;
+		const uri = log.runs[0]?.results[0]?.locations[0]?.physicalLocation.artifactLocation.uri;
+		expect(uri).toBe("src/a/b.ts");
+		expect(region).toEqual({ startLine: 1, startColumn: 1 });
+	});
+});

--- a/tests/scoring/rule-severity.test.ts
+++ b/tests/scoring/rule-severity.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from "vitest";
+import type { Diagnostic } from "../../src/engines/types.js";
+import { applyRuleSeverities } from "../../src/scoring/rule-severity.js";
+
+const createDiagnostic = (overrides: Partial<Diagnostic> = {}): Diagnostic => ({
+	filePath: "src/example.ts",
+	engine: "ai-slop",
+	rule: "ai-slop/narrative-comment",
+	severity: "warning",
+	message: "Narrative comment",
+	help: "Remove the comment",
+	line: 1,
+	column: 1,
+	category: "comments",
+	fixable: true,
+	...overrides,
+});
+
+describe("applyRuleSeverities", () => {
+	it("returns diagnostics untouched when no overrides are set", () => {
+		const diagnostics = [createDiagnostic()];
+		expect(applyRuleSeverities(diagnostics, {})).toBe(diagnostics);
+	});
+
+	it("drops diagnostics for rules set to off", () => {
+		const diagnostics = [
+			createDiagnostic({ rule: "ai-slop/todo-stub" }),
+			createDiagnostic({ rule: "ai-slop/narrative-comment" }),
+		];
+		const result = applyRuleSeverities(diagnostics, { "ai-slop/todo-stub": "off" });
+		expect(result.map((d) => d.rule)).toEqual(["ai-slop/narrative-comment"]);
+	});
+
+	it("rewrites severity for overridden rules", () => {
+		const diagnostics = [createDiagnostic({ severity: "warning" })];
+		const result = applyRuleSeverities(diagnostics, {
+			"ai-slop/narrative-comment": "error",
+		});
+		expect(result[0]?.severity).toBe("error");
+	});
+
+	it("leaves unmatched rules at their original severity", () => {
+		const diagnostics = [
+			createDiagnostic({ rule: "security/hardcoded-secret", severity: "error" }),
+		];
+		const result = applyRuleSeverities(diagnostics, {
+			"ai-slop/narrative-comment": "off",
+		});
+		expect(result[0]?.severity).toBe("error");
+	});
+});


### PR DESCRIPTION
- SARIF 2.1.0 output via --sarif / --format sarif on scan and ci (GitHub code scanning / IDE interop).
- Per-rule severity overrides in config (rules: { id: error|warning|off }).
- aislop trend command + .aislop/history.jsonl score history with sparkline.
- Generated JSON Schema for .aislop/config.yml (schema/, pnpm gen:schema).
- .pre-commit-hooks.yaml for the pre-commit framework.
- VS Code extension scaffold (editors/vscode) and fix-to-PR design doc (docs/plans).
- Public research program protocol (docs/research-program.md).

Verified: tsc --noEmit, pnpm build, full test suite (874 passing incl. 14 new), self-scan clean.
