### PR TITLE
Release 0.9.6: promote develop to main

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Precision fix for the `hardcoded-id` / `hardcoded-url` rules shipped in 0.9.5, w
 
 - **`ai-slop/hardcoded-id` false positives.** No longer flags: env-var-name literals passed to config helpers (e.g. `optional("STRIPE_PRICE_ID", "")`), readable kebab/snake slugs and storage keys (rule keys, `STORAGE_KEY` values, CSS class strings), or identifiers inside DB migration files. The rule now requires an opaque, digit-bearing token, so genuine provider/project IDs (`price_1Oabc…`, AWS keys, OAuth client IDs) are still caught.
 - **`ai-slop/hardcoded-url` false positives.** No longer flags `localhost` / loopback URLs (`http://localhost:…`, `127.0.0.1`, `0.0.0.0`), which are dev defaults rather than deployment configuration.
+- **`ai-slop/hallucinated-import` on `psycopg2`.** The `psycopg2` import is now recognised as provided by `psycopg2-binary` (community-reported). Adds the missing alias.
 
 ### Tests
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,19 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.9.6 (2026-05-30)
+
+Precision fix for the `hardcoded-id` / `hardcoded-url` rules shipped in 0.9.5, which over-flagged on real codebases (surfaced by dogfooding the rules on our own dashboard).
+
+### Fixed
+
+- **`ai-slop/hardcoded-id` false positives.** No longer flags: env-var-name literals passed to config helpers (e.g. `optional("STRIPE_PRICE_ID", "")`), readable kebab/snake slugs and storage keys (rule keys, `STORAGE_KEY` values, CSS class strings), or identifiers inside DB migration files. The rule now requires an opaque, digit-bearing token, so genuine provider/project IDs (`price_1Oabc…`, AWS keys, OAuth client IDs) are still caught.
+- **`ai-slop/hardcoded-url` false positives.** No longer flags `localhost` / loopback URLs (`http://localhost:…`, `127.0.0.1`, `0.0.0.0`), which are dev defaults rather than deployment configuration.
+
+### Tests
+
+Full suite at 933 passing, including regression coverage for each false-positive class above.
+
 ## 0.9.5 (2026-05-30)
 
 First release since the Hacker News launch. Fixes the Python import false positives reported there, adds two precision-first rules, ships the SARIF / per-rule-severity / `trend` tooling from #140, and extends agent support to pi (both the `fix` hand-off and an auto-running hook).

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aislop",
-  "version": "0.9.5",
+  "version": "0.9.6",
   "description": "Catch the slop AI coding agents leave in your code: narrative comments, swallowed exceptions, as-any casts, dead code, oversized functions. 40+ rules across 7 languages (TS/JS, Python, Go, Rust, Ruby, PHP, Java). Sub-second, deterministic, no LLM at runtime. MIT-licensed.",
   "type": "module",
   "bin": {

--- a/src/engines/ai-slop/hardcoded-config.ts
+++ b/src/engines/ai-slop/hardcoded-config.ts
@@ -31,7 +31,9 @@ const ENVIRONMENT_HOST_RE =
 	/(?:^|[.-])(?:api|app|admin|auth|staging|stage|prod|dev|sandbox|webhook|internal)(?:[.-]|$)|^(?:localhost|127\.0\.0\.1|0\.0\.0\.0)$/i;
 const ID_CONTEXT_RE =
 	/(?:^|[^A-Za-z0-9])(?:api[_-]?key|client[_-]?id|project[_-]?id|org(?:anization)?[_-]?id|workspace[_-]?id|tenant[_-]?id|price[_-]?id|product[_-]?id|customer[_-]?id|subscription[_-]?id|account[_-]?id|app[_-]?id|key|token|secret)(?:$|[^A-Za-z0-9])/i;
+const MIGRATION_PATH_RE = /(?:^|[\\/])(?:migrations?|db[\\/]migrate)[\\/]/i;
 const PLACEHOLDER_HOSTS = new Set(["example.com", "example.org", "example.net"]);
+const LOOPBACK_HOSTS = new Set(["localhost", "127.0.0.1", "0.0.0.0", "::1"]);
 const PLACEHOLDER_ID_RE = /^(?:changeme|replace[_-]?me|your[_-]|example|placeholder|todo)/i;
 
 interface FindingSpec {
@@ -93,15 +95,20 @@ const shouldFlagUrlLiteral = (line: string, urlText: string): boolean => {
 	const host = safeUrlHost(urlText);
 	if (!host) return false;
 	if (PLACEHOLDER_HOSTS.has(host)) return false;
+	if (LOOPBACK_HOSTS.has(host)) return false;
 	if (DOC_URL_CONTEXT_RE.test(line) && !ENVIRONMENT_HOST_RE.test(host)) return false;
 	return URL_CONFIG_CONTEXT_RE.test(line) || ENVIRONMENT_HOST_RE.test(host);
 };
 
+const ENV_VAR_NAME_RE = /^[A-Z][A-Z0-9]*(?:_[A-Z0-9]+)+$/;
+
 const hasUsefulIdShape = (value: string): boolean => {
 	if (PLACEHOLDER_ID_RE.test(value)) return false;
+	if (ENV_VAR_NAME_RE.test(value)) return false;
 	if (/^https?:\/\//i.test(value)) return false;
 	if (/^[A-Za-z]+$/.test(value)) return false;
-	return /[0-9_-]/.test(value);
+	// A digit separates an opaque ID from a readable slug/storage key.
+	return /[0-9]/.test(value);
 };
 
 const scanLineForConfigLiterals = (
@@ -146,6 +153,7 @@ const scanFileForConfigLiterals = (
 ): Diagnostic[] => {
 	if (!SOURCE_EXTENSIONS.has(ext)) return [];
 	if (isNonProductionPath(relativePath)) return [];
+	if (MIGRATION_PATH_RE.test(relativePath)) return [];
 
 	return content
 		.split("\n")

--- a/src/engines/ai-slop/python-data.ts
+++ b/src/engines/ai-slop/python-data.ts
@@ -184,6 +184,7 @@ export const PYTHON_IMPORT_TO_PIP: Record<string, string[]> = {
 	pptx: ["python-pptx"],
 	git: ["gitpython"],
 	socks: ["pysocks"],
+	psycopg2: ["psycopg2-binary", "psycopg2"],
 	redis: ["redis"],
 	cairo: ["pycairo"],
 	serial: ["pyserial"],

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,1 +1,1 @@
-export const APP_VERSION = process.env.VERSION ?? "0.9.5";
+export const APP_VERSION = process.env.VERSION ?? "0.9.6";

--- a/tests/dead-patterns.test.ts
+++ b/tests/dead-patterns.test.ts
@@ -308,6 +308,18 @@ describe("hardcoded config literals", () => {
 		expect(diagnostics.filter((d) => d.rule === "ai-slop/hardcoded-url")).toEqual([]);
 	});
 
+	it("does not flag localhost / loopback URLs (dev defaults)", async () => {
+		const filePath = writeFile(
+			"dev-config.ts",
+			[
+				'const origin = optional("CORS_ORIGIN", "http://localhost:5173");',
+				'const proxyTarget = "http://127.0.0.1:3001";',
+			].join("\n"),
+		);
+		const diagnostics = await detectHardcodedConfigLiterals(makeContext([filePath]));
+		expect(diagnostics.filter((d) => d.rule === "ai-slop/hardcoded-url")).toEqual([]);
+	});
+
 	it("does not flag documentation links", async () => {
 		const filePath = writeFile(
 			"docs-link.ts",
@@ -338,6 +350,46 @@ describe("hardcoded config literals", () => {
 		const filePath = writeFile(
 			"billing-env.ts",
 			'const STRIPE_PRICE_ID = process.env.STRIPE_PRICE_ID ?? "price_123456789abcdef";',
+		);
+		const diagnostics = await detectHardcodedConfigLiterals(makeContext([filePath]));
+		expect(diagnostics.filter((d) => d.rule === "ai-slop/hardcoded-id")).toEqual([]);
+	});
+
+	it("does not flag env-var-name literals passed to a config helper", async () => {
+		const filePath = writeFile(
+			"config.ts",
+			[
+				'const github = { clientId: optional("GITHUB_CLIENT_ID", "") };',
+				'const stripe = { priceProMonthly: optional("STRIPE_PRICE_PRO_MONTHLY", "") };',
+			].join("\n"),
+		);
+		const diagnostics = await detectHardcodedConfigLiterals(makeContext([filePath]));
+		expect(diagnostics.filter((d) => d.rule === "ai-slop/hardcoded-id")).toEqual([]);
+	});
+
+	it("still flags a real provider ID even on a SCREAMING_SNAKE-named const", async () => {
+		const filePath = writeFile("real-id.ts", 'const STRIPE_PRICE_ID = "price_1OabcdEFghijKLmn";');
+		const diagnostics = await detectHardcodedConfigLiterals(makeContext([filePath]));
+		expect(diagnostics.filter((d) => d.rule === "ai-slop/hardcoded-id")).toHaveLength(1);
+	});
+
+	it("does not flag readable kebab/snake slugs and storage keys", async () => {
+		const filePath = writeFile(
+			"slugs.ts",
+			[
+				'const STORAGE_KEY = "scanaislop_theme";',
+				'const entry = { key: "swallowed-exception" };',
+				'const map = { "hardcoded-secret": ["security/hardcoded-secret"] };',
+			].join("\n"),
+		);
+		const diagnostics = await detectHardcodedConfigLiterals(makeContext([filePath]));
+		expect(diagnostics.filter((d) => d.rule === "ai-slop/hardcoded-id")).toEqual([]);
+	});
+
+	it("does not flag hardcoded IDs in DB migration files", async () => {
+		const filePath = writeFile(
+			"packages/api/src/db/migrations/0001-indexes.ts",
+			'export const up = () => createIndex("idx_scans_org_created_at_desc", "price_123456789abcdef");',
 		);
 		const diagnostics = await detectHardcodedConfigLiterals(makeContext([filePath]));
 		expect(diagnostics.filter((d) => d.rule === "ai-slop/hardcoded-id")).toEqual([]);

--- a/tests/hallucinated-imports.test.ts
+++ b/tests/hallucinated-imports.test.ts
@@ -446,6 +446,20 @@ import sklearn.cluster as cluster
 		expect(diagnostics).toEqual([]);
 	});
 
+	it("resolves psycopg2 provided by psycopg2-binary (discussion #130)", async () => {
+		writeFile("pyproject.toml", `[project]\ndependencies = ["psycopg2-binary>=2.9"]\n`);
+		writeFile(
+			"src/export_db.py",
+			`import psycopg2
+from psycopg2 import extras
+`,
+		);
+
+		const diagnostics = await detectHallucinatedImports(buildContext());
+
+		expect(diagnostics).toEqual([]);
+	});
+
 	it("resolves install-name vs import-name divergences from the HN/issue-143 report", async () => {
 		writeFile(
 			"requirements.txt",


### PR DESCRIPTION
Promotes `develop` to `main` for the **0.9.6** patch release.

### Included (#149)
- **`ai-slop/hardcoded-id` false-positive fix** — no longer flags env-var-name literals, readable slugs/storage keys, or DB-migration identifiers; now requires a digit-bearing opaque token so real provider IDs are still caught.
- **`ai-slop/hardcoded-url` false-positive fix** — no longer flags localhost/loopback dev defaults.
- **Release bump to 0.9.6** + CHANGELOG.

Surfaced by dogfooding the 0.9.5 rules on our dashboard (40 `hardcoded-id` findings there were all false positives → now 0).

### After merge
Tag `v0.9.6` on `main` (or publish the prepared draft release) to trigger publish → npm + GitHub Packages + GitHub Release.

Verified on develop: tsc clean, 933 tests passing, build ok, self-scan 100/100.
