### PR TITLE
fix(ai-slop): recognize psycopg2 provided by psycopg2-binary (#130)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Precision fix for the `hardcoded-id` / `hardcoded-url` rules shipped in 0.9.5, w
 
 - **`ai-slop/hardcoded-id` false positives.** No longer flags: env-var-name literals passed to config helpers (e.g. `optional("STRIPE_PRICE_ID", "")`), readable kebab/snake slugs and storage keys (rule keys, `STORAGE_KEY` values, CSS class strings), or identifiers inside DB migration files. The rule now requires an opaque, digit-bearing token, so genuine provider/project IDs (`price_1Oabc…`, AWS keys, OAuth client IDs) are still caught.
 - **`ai-slop/hardcoded-url` false positives.** No longer flags `localhost` / loopback URLs (`http://localhost:…`, `127.0.0.1`, `0.0.0.0`), which are dev defaults rather than deployment configuration.
+- **`ai-slop/hallucinated-import` on `psycopg2`.** The `psycopg2` import is now recognised as provided by `psycopg2-binary` (community-reported). Adds the missing alias.
 
 ### Tests
 

--- a/src/engines/ai-slop/python-data.ts
+++ b/src/engines/ai-slop/python-data.ts
@@ -184,6 +184,7 @@ export const PYTHON_IMPORT_TO_PIP: Record<string, string[]> = {
 	pptx: ["python-pptx"],
 	git: ["gitpython"],
 	socks: ["pysocks"],
+	psycopg2: ["psycopg2-binary", "psycopg2"],
 	redis: ["redis"],
 	cairo: ["pycairo"],
 	serial: ["pyserial"],

--- a/tests/hallucinated-imports.test.ts
+++ b/tests/hallucinated-imports.test.ts
@@ -446,6 +446,20 @@ import sklearn.cluster as cluster
 		expect(diagnostics).toEqual([]);
 	});
 
+	it("resolves psycopg2 provided by psycopg2-binary (discussion #130)", async () => {
+		writeFile("pyproject.toml", `[project]\ndependencies = ["psycopg2-binary>=2.9"]\n`);
+		writeFile(
+			"src/export_db.py",
+			`import psycopg2
+from psycopg2 import extras
+`,
+		);
+
+		const diagnostics = await detectHallucinatedImports(buildContext());
+
+		expect(diagnostics).toEqual([]);
+	});
+
 	it("resolves install-name vs import-name divergences from the HN/issue-143 report", async () => {
 		writeFile(
 			"requirements.txt",


### PR DESCRIPTION
Fixes a `ai-slop/hallucinated-import` false positive reported in discussion #130: `import psycopg2` was flagged when the project declares `psycopg2-binary` (the official prebuilt wheel that provides the `psycopg2` module).

Adds the missing alias `psycopg2 → [psycopg2-binary, psycopg2]` to `PYTHON_IMPORT_TO_PIP`, same pattern as `PIL`→pillow, `yaml`→pyyaml.

Folded into the unreleased **0.9.6** (CHANGELOG updated). Regression test added — verified it fails without the alias and passes with it.

Verified: tsc clean, full suite 934 passing, self-scan 100/100.
