### PR TITLE
docs(changelog): fold notifier + comment-bleed into the 0.10.1 entry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,11 +6,17 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## 0.10.1 (2026-05-30)
 
-A complexity-accuracy release. The Python function detector was only seeing single-line synchronous `def`s, so async functions and wrapped multi-line signatures (about 58% of a large library like python-telegram-bot) were invisible to `function-too-long`, `too-many-params`, and `deep-nesting`. Fixing detection alone over-corrected, so the length and parameter metrics were sharpened to measure real complexity rather than documentation or optional API surface.
+An accuracy release across Python and TypeScript, plus a small quality-of-life feature. The Python function detector was only seeing single-line synchronous `def`s, so async functions and wrapped multi-line signatures (about 58% of a large library like python-telegram-bot) were invisible to the complexity rules. In TypeScript, text-pattern rules were matching code inside JSDoc `@example` blocks as if it were live source. Both are fixed, and the complexity metrics were sharpened to measure real complexity rather than documentation or optional API surface.
+
+### Added
+
+- **Update notice.** The CLI prints a one-line "update available" notice when a newer version exists. It is cache-backed so it never blocks a run, and silent in CI, in non-interactive output, and when opted out via `AISLOP_NO_UPDATE_NOTIFIER`, `NO_UPDATE_NOTIFIER`, or `DO_NOT_TRACK`.
 
 ### Fixed
 
 - **Python function detection** now recognises `async def` and multi-line wrapped signatures (where `):` sits on its own line). Previously these functions were skipped entirely by the code-quality engine.
+- **JSDoc/TSDoc comment bleed.** Text-pattern rules no longer scan code inside `/** @example */` blocks, the largest false-positive source on documented TS/JS libraries. This covers `duplicate-import`, `console-leftover`, `empty-function`, `generic-naming`, `thin-wrapper`, `hardcoded-url` / `hardcoded-id`, and `security/hardcoded-secret`. On type-fest, `duplicate-import` dropped from 143 to 0; an error-severity `hardcoded-secret` on a password inside a Hono doc example is gone; genuine findings such as zod's real `as any` are preserved.
+- **`ai-slop/duplicate-import`** no longer flags a namespace import (`import * as x`) alongside a named import from the same module. The two cannot be merged into one statement, so they were never a real duplicate.
 
 ### Changed
 
@@ -19,7 +25,7 @@ A complexity-accuracy release. The Python function detector was only seeing sing
 
 ### Tests
 
-Full suite at 953 passing. New coverage for async detection, wrapped signatures, required-only parameter counting, and docstring-aware length, plus a regression net: a realistic Python corpus with golden per-rule assertions and a detection-invariant check (functions detected vs `def`/`async def` count) that fails on the pre-0.10.1 detector.
+Full suite at 975 passing. New coverage for async detection, wrapped signatures, required-only parameter counting, docstring-aware length, comment masking, the `@example` import and secret cases, and the update notifier, plus a regression net: a realistic Python corpus with golden per-rule assertions and a detection-invariant check (functions detected vs `def`/`async def` count) that fails on the pre-0.10.1 detector.
 
 ## 0.10.0 (2026-05-30)
 


### PR DESCRIPTION
Shipping all three merged changes as 0.10.1, so the CHANGELOG 0.10.1 entry now documents all of them, not just the complexity fix.

- Broadened the intro (Python + TypeScript accuracy, plus the update notice).
- Added the update notifier under Added.
- Added the JSDoc comment-bleed fix and the namespace-import fix under Fixed.
- Updated the test count to 975 (combined on develop).

Matches the draft v0.10.1 release notes and PR #160.