### PR TITLE
fix(rules): complete the aislop rules catalog + drift guard

### DIFF
--- a/src/commands/rules.ts
+++ b/src/commands/rules.ts
@@ -73,6 +73,8 @@ const AI_SLOP_FIXABLE = new Set<string>([
 
 const AI_SLOP_ERRORS = new Set<string>(["ai-slop/hallucinated-import"]);
 
+const SECURITY_INFO = new Set<string>(["security/dependency-audit-skipped"]);
+
 const BUILTIN_RULES: { engine: string; rules: string[] }[] = [
 	{
 		engine: "format",
@@ -101,6 +103,10 @@ const BUILTIN_RULES: { engine: string; rules: string[] }[] = [
 			"knip/binaries",
 			"knip/exports",
 			"knip/types",
+			"knip/duplicates",
+			"code-quality/duplicate-block",
+			"code-quality/repeated-chained-call",
+			"code-quality/unused-declaration",
 			"complexity/file-too-large",
 			"complexity/function-too-long",
 			"complexity/deep-nesting",
@@ -153,18 +159,31 @@ const BUILTIN_RULES: { engine: string; rules: string[] }[] = [
 			"security/vulnerable-dependency",
 			"security/eval",
 			"security/innerhtml",
+			"security/dangerously-set-innerhtml",
 			"security/sql-injection",
 			"security/shell-injection",
+			"security/dependency-audit-skipped",
 		],
 	},
 ];
+
+// The native rule IDs the catalog advertises (excludes lint/format wildcards).
+export const catalogRuleIds = (): string[] =>
+	BUILTIN_RULES.flatMap((b) => b.rules).filter((id) =>
+		/^(?:ai-slop|complexity|security|code-quality|knip)\/[a-z0-9-]+$/.test(id),
+	);
 
 const toRuleEntry = (engine: string, ruleId: string): RuleEntry => {
 	if (engine === "format") {
 		return { id: ruleId, engine, severity: "warning", fixable: true };
 	}
 	if (engine === "security") {
-		return { id: ruleId, engine, severity: "error", fixable: false };
+		return {
+			id: ruleId,
+			engine,
+			severity: SECURITY_INFO.has(ruleId) ? "info" : "error",
+			fixable: false,
+		};
 	}
 	if (engine === "ai-slop") {
 		return {

--- a/tests/commands/rules.catalog.test.ts
+++ b/tests/commands/rules.catalog.test.ts
@@ -1,0 +1,37 @@
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+import { catalogRuleIds } from "../../src/commands/rules.js";
+
+const ENGINES_DIR = fileURLToPath(new URL("../../src/engines", import.meta.url));
+const RULE_ID_RE = /["'`]((?:ai-slop|complexity|security|code-quality|knip)\/[a-z0-9-]+)["'`]/g;
+
+const walk = (dir: string): string[] => {
+	const out: string[] = [];
+	for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+		const full = path.join(dir, entry.name);
+		if (entry.isDirectory()) out.push(...walk(full));
+		else if (entry.name.endsWith(".ts")) out.push(full);
+	}
+	return out;
+};
+
+const emittedRuleIds = (): Set<string> => {
+	const ids = new Set<string>();
+	for (const file of walk(ENGINES_DIR)) {
+		const source = fs.readFileSync(file, "utf-8");
+		for (const match of source.matchAll(RULE_ID_RE)) ids.add(match[1]);
+	}
+	return ids;
+};
+
+describe("rules catalog completeness", () => {
+	it("lists every native rule the engines emit (no silent drift)", () => {
+		const catalog = new Set(catalogRuleIds());
+		const missing = [...emittedRuleIds()].filter((id) => !catalog.has(id)).sort();
+		expect(missing, `rule(s) emitted by an engine but absent from aislop rules: ${missing.join(", ")}`).toEqual(
+			[],
+		);
+	});
+});


### PR DESCRIPTION
## Problem
`aislop rules` is meant to be the canonical rule catalog (users and the agent skill rely on it), but its list (`BUILTIN_RULES`) is hand-maintained and had drifted from what the engines actually emit. Six emitted rules were missing. This is what gave a wrong rule-ID list during the skill PR review.

## Fix
Added the six missing rules:
- `code-quality/duplicate-block`
- `code-quality/repeated-chained-call`
- `code-quality/unused-declaration`
- `knip/duplicates`
- `security/dangerously-set-innerhtml`
- `security/dependency-audit-skipped` (rendered as **info**, matching the engine; the catalog previously forced all security rules to error)

0 stale entries (everything already listed is still emitted).

## Drift guard
Added `tests/commands/rules.catalog.test.ts`: it scans `src/engines` for emitted rule-ID literals and fails if any is absent from the catalog. This is the test that would have caught the drift, so the hand-maintained list can't silently fall behind again. Full suite green (89 files).