### PR TITLE
fix(fixer): console removal no longer guts functions or silences dev scripts

### DIFF
--- a/src/engines/ai-slop/dead-patterns-fix.ts
+++ b/src/engines/ai-slop/dead-patterns-fix.ts
@@ -65,6 +65,27 @@ const shouldUpgradeToError = (statementText: string): boolean => {
 	return ERROR_MESSAGE_PATTERNS.some((pattern) => pattern.test(statementText));
 };
 
+// In diagnostic scripts the console output is the point, so do not strip it.
+const DIAGNOSTIC_PATH_RE =
+	/(?:^|\/)(?:tools|scripts|cli|bin)\/|(?:^|\/)test-[^/]*\.[tj]sx?$|[.-](?:test|spec)\.[tj]sx?$/i;
+const isDiagnosticScriptPath = (filePath: string): boolean =>
+	DIAGNOSTIC_PATH_RE.test(filePath.replace(/\\/g, "/"));
+
+const firstNonBlank = (lines: string[], from: number, step: number): string => {
+	for (let i = from; i >= 0 && i < lines.length; i += step) {
+		if (lines[i].trim() !== "") return lines[i].trim();
+	}
+	return "";
+};
+
+// Removing the only statement in a block guts the function, so leave it for a human.
+const wouldEmptyEnclosingBlock = (lines: string[], span: Set<number>): boolean => {
+	const sorted = [...span].sort((a, b) => a - b);
+	const before = firstNonBlank(lines, sorted[0] - 2, -1);
+	const after = firstNonBlank(lines, sorted[sorted.length - 1], 1);
+	return before.endsWith("{") && after.startsWith("}");
+};
+
 export const fixDeadPatterns = async (context: EngineContext): Promise<void> => {
 	const diagnostics = [
 		...(await detectTrivialComments(context)),
@@ -102,6 +123,7 @@ const fixFileDeadPatterns = (filePath: string, entries: { line: number; rule: st
 		if (index < 0 || index >= lines.length) continue;
 
 		if (entry.rule === "ai-slop/console-leftover") {
+			if (isDiagnosticScriptPath(filePath)) continue;
 			const span = findStatementSpan(lines, index);
 			const statementText = getStatementText(lines, index, span);
 
@@ -112,6 +134,7 @@ const fixFileDeadPatterns = (filePath: string, entries: { line: number; rule: st
 				);
 				lineReplacements.set(entry.line, replaced);
 			} else {
+				if (wouldEmptyEnclosingBlock(lines, span)) continue;
 				for (const lineNo of span) {
 					linesToRemove.add(lineNo);
 				}

--- a/tests/dead-patterns-fix.test.ts
+++ b/tests/dead-patterns-fix.test.ts
@@ -345,3 +345,57 @@ describe("fixDeadPatterns — mixed console handling", () => {
 		expect(result).not.toContain("Remove me");
 	});
 });
+
+// ─── Safety: do not gut side-effect-only functions or diagnostic scripts ──────
+
+describe("fixDeadPatterns — does not create silent regressions", () => {
+	it("leaves a console that is the only statement in its block", async () => {
+		const file = writeFile(
+			"logger.ts",
+			[
+				"export const logIfEnabled = (message: string, tag = 'app') => {",
+				"    if (loggingEnabled()) {",
+				"        console.log(`[${tag}] ${message}`);",
+				"    }",
+				"};",
+			].join("\n"),
+		);
+
+		await fixDeadPatterns(makeContext([file]));
+		const result = readFile("logger.ts");
+
+		// Removing it would leave an empty function body, so it must be left for a human.
+		expect(result).toContain("console.log(`[${tag}] ${message}`)");
+	});
+
+	it("leaves console output in diagnostic scripts (Pattern 4)", async () => {
+		const file = writeFile(
+			"tools/test-tools.ts",
+			[
+				"export function diagnose() {",
+				"    const results = collect();",
+				"    console.log(results);",
+				"    return results;",
+				"}",
+			].join("\n"),
+		);
+
+		await fixDeadPatterns(makeContext([file]));
+		const result = readFile("tools/test-tools.ts");
+
+		expect(result).toContain("console.log(results)");
+	});
+
+	it("still removes ordinary debug console in regular source", async () => {
+		const file = writeFile(
+			"app.ts",
+			["export function run() {", '    console.log("debug");', "    return 1;", "}"].join("\n"),
+		);
+
+		await fixDeadPatterns(makeContext([file]));
+		const result = readFile("app.ts");
+
+		expect(result).not.toContain("console.log");
+		expect(result).toContain("return 1;");
+	});
+});


### PR DESCRIPTION
The `console-leftover` fixer removed the statement line-by-line without checking what it left behind. Two safety gaps:

## Gutted function bodies
A side-effect-only logger like:
```ts
export const logIfEnabled = (message) => {
  if (loggingEnabled()) {
    console.log(message);
  }
};
```
got its `console.log` removed, leaving an empty `if` body and a function that silently does nothing (and its now-unused params got renamed to `_`). Now: if removing the console would empty the enclosing block, skip it and leave it for a human. The finding still reports; we just do not auto-gut it.

## Dev / diagnostic scripts
In `tools/`, `scripts/`, `cli/`, `bin/`, and `test-*` / `*.test.*` / `*.spec.*` files, `console.log` is the output, not leftover debugging. Console removal is skipped there, which also closes the downstream unused-variable cascade.

## Notes
- Ordinary debug-console removal in regular source is unchanged (existing tests).
- 75 tests pass (incl. 3 new), tsc clean, aislop 100.

Base develop; not merged.
