### PR TITLE
fix(fixer): stop auto-stripping aria-hidden and empty-fallback spread guards

### DIFF
--- a/src/engines/lint/oxlint-config.ts
+++ b/src/engines/lint/oxlint-config.ts
@@ -82,6 +82,8 @@ export const createOxlintConfig = (options: OxlintConfigOptions): Record<string,
 		rules["react-hooks/exhaustive-deps"] = "off";
 		// Its autofix deletes aria-hidden, which breaks the sr-only submit-on-Enter pattern.
 		rules["jsx-a11y/no-aria-hidden-on-focusable"] = "off";
+		// `... (x || {})` is often a deliberate undefined guard and breaks under noUncheckedIndexedAccess.
+		rules["unicorn/no-useless-fallback-in-spread"] = "off";
 	}
 
 	const plugins = ["import", "unicorn", "typescript", ...buildFrameworkPlugins(options.framework)];

--- a/src/engines/lint/oxlint-config.ts
+++ b/src/engines/lint/oxlint-config.ts
@@ -80,6 +80,8 @@ export const createOxlintConfig = (options: OxlintConfigOptions): Record<string,
 	if (options.mode === "fix") {
 		rules["no-unused-vars"] = "off";
 		rules["react-hooks/exhaustive-deps"] = "off";
+		// Its autofix deletes aria-hidden, which breaks the sr-only submit-on-Enter pattern.
+		rules["jsx-a11y/no-aria-hidden-on-focusable"] = "off";
 	}
 
 	const plugins = ["import", "unicorn", "typescript", ...buildFrameworkPlugins(options.framework)];

--- a/tests/oxlint-config.test.ts
+++ b/tests/oxlint-config.test.ts
@@ -10,8 +10,14 @@ describe("createOxlintConfig — fixer safety", () => {
 		expect(rules["jsx-a11y/no-aria-hidden-on-focusable"]).toBe("off");
 	});
 
-	it("leaves the rule untouched outside fix mode so the scan can still surface it", () => {
+	it("does not let the fixer strip a deliberate empty-fallback guard in a spread", () => {
+		const rules = rulesOf(createOxlintConfig({ mode: "fix" }));
+		expect(rules["unicorn/no-useless-fallback-in-spread"]).toBe("off");
+	});
+
+	it("leaves both rules untouched outside fix mode so the scan can still surface them", () => {
 		const rules = rulesOf(createOxlintConfig({ framework: "react", mode: "detect" }));
 		expect(rules["jsx-a11y/no-aria-hidden-on-focusable"]).toBeUndefined();
+		expect(rules["unicorn/no-useless-fallback-in-spread"]).toBeUndefined();
 	});
 });

--- a/tests/oxlint-config.test.ts
+++ b/tests/oxlint-config.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from "vitest";
+import { createOxlintConfig } from "../src/engines/lint/oxlint-config.js";
+
+const rulesOf = (config: Record<string, unknown>): Record<string, string> =>
+	config.rules as Record<string, string>;
+
+describe("createOxlintConfig — fixer safety", () => {
+	it("does not let the fixer strip aria-hidden from focusable elements", () => {
+		const rules = rulesOf(createOxlintConfig({ framework: "react", mode: "fix" }));
+		expect(rules["jsx-a11y/no-aria-hidden-on-focusable"]).toBe("off");
+	});
+
+	it("leaves the rule untouched outside fix mode so the scan can still surface it", () => {
+		const rules = rulesOf(createOxlintConfig({ framework: "react", mode: "detect" }));
+		expect(rules["jsx-a11y/no-aria-hidden-on-focusable"]).toBeUndefined();
+	});
+});


### PR DESCRIPTION
The auto-fixer was deleting intentional defensive code via two oxlint autofixes that change behaviour or semantics. Both are now disabled in **fix mode only** (scan still reports them), alongside the risky autofixes already turned off there (`no-unused-vars`, `react-hooks/exhaustive-deps`).

## 1. `jsx-a11y/no-aria-hidden-on-focusable` — strips `aria-hidden`
```tsx
<button type="submit" className="sr-only" aria-hidden />
```
The autofix removes `aria-hidden`, breaking the visually-hidden submit-on-Enter pattern and leaving screen-reader users a phantom unlabelled button. The scan did not even report it, so `fix` stripped it silently. The correct fix is usually `tabindex`, not deletion, so it is not a safe mechanical edit.

## 2. `unicorn/no-useless-fallback-in-spread` — strips `|| {}` guards
```ts
const x = { ...(draft.avail || {}) };  // -> { ...draft.avail }
```
That guard is frequently deliberate: `draft.avail` is `T | undefined`, the `|| {}` documents that, and the rewrite becomes a type error under `noUncheckedIndexedAccess`. Removing it treats a runtime invariant as a style preference.

## Verified
- Unit tests: both rules `off` in fix mode, untouched in detect mode.
- End-to-end: running the CLI `fix` on each snippet now leaves the code intact.
- tsc clean, aislop 100.

Base develop; not merged.
