### PR TITLE
feat(suppress): inline aislop-ignore directives and .aislopignore

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Added
+
+- **Suppression.** Silence a finding you have judged intentional with an inline directive: `// aislop-ignore-next-line [rule...]` (line below), `// aislop-ignore-line [rule...]` (same line), or `// aislop-ignore-file [rule...]` (whole file). Name one or more rules to scope it, or omit them to silence every rule on that line, and add a reason after `--`. Works in any comment syntax (`//`, `#`, `<!-- -->`). Directive lines are invisible to the comment engines, so they never join a comment block or get flagged themselves. Suppressed findings are dropped before scoring, and the run reports how many were silenced.
+- **`.aislopignore`.** A root-level ignore file (same glob semantics as the `exclude` config, with `#` comments) to keep whole paths out of every scan.
+
 ## 0.10.1 (2026-05-30)
 
 An accuracy release across Python and TypeScript, plus a small quality-of-life feature. The Python function detector was only seeing single-line synchronous `def`s, so async functions and wrapped multi-line signatures (about 58% of a large library like python-telegram-bot) were invisible to the complexity rules. In TypeScript, text-pattern rules were matching code inside JSDoc `@example` blocks as if it were live source. Both are fixed, and the complexity metrics were sharpened to measure real complexity rather than documentation or optional API surface.

--- a/README.md
+++ b/README.md
@@ -102,6 +102,25 @@ rules:
 
 `off` drops matching diagnostics; `error`/`warning` rewrites severity before scoring and reporting. Absent map keeps default behavior.
 
+**Suppress findings inline**: Silence a specific line when you know better, with an optional reason after `--`:
+
+```ts
+// aislop-ignore-next-line ai-slop/empty-fallback -- options is validated upstream
+const opts = { ...defaults, ...(input || {}) };
+
+const legacy = doThing(); // aislop-ignore-line
+```
+
+`aislop-ignore-next-line` covers the line below, `aislop-ignore-line` the line it sits on, and `aislop-ignore-file` (place anywhere in the file) the whole file. Name one or more rules to scope the suppression, or omit them to silence every rule on that line. The directive works in any comment syntax (`//`, `#`, `<!-- -->`). Suppressed findings are removed before scoring, and the run reports how many were silenced.
+
+**Ignore whole paths**: Add an `.aislopignore` at the project root (same glob semantics as `exclude`, `#` comments allowed):
+
+```
+src/generated
+**/*.snap
+legacy
+```
+
 **Extend config**: Project config can extend a parent:
 
 ```yaml

--- a/src/commands/scan.ts
+++ b/src/commands/scan.ts
@@ -1,32 +1,37 @@
 import fs from "node:fs";
 import path from "node:path";
 import { performance } from "node:perf_hooks";
-import { findConfigDir, RULES_FILE, type AislopConfig } from "../config/index.js";
+import { type AislopConfig, findConfigDir, RULES_FILE } from "../config/index.js";
 import { runEngines } from "../engines/orchestrator.js";
 import type { Diagnostic, EngineConfig, EngineName, EngineResult } from "../engines/types.js";
 import { ENGINE_INFO, getEngineLabel } from "../output/engine-info.js";
 import { printEngineStatus, renderDiagnostics } from "../output/terminal.js";
 import { calculateScore } from "../scoring/index.js";
 import { applyRuleSeverities } from "../scoring/rule-severity.js";
+import { isCiEnv } from "../telemetry/env.js";
+import { type EngineCounts, withCommandLifecycle } from "../telemetry/index.js";
 import { renderHeader } from "../ui/header.js";
 import { detectInvocation } from "../ui/invocation.js";
 import { type GridRow, type GridRowOutcome, LiveGrid } from "../ui/live-grid.js";
 import { log } from "../ui/logger.js";
 import {
 	type BreakdownSummary,
+	type NextStep,
 	renderCleanRun,
 	renderStarCta,
 	renderSummary,
-	type NextStep,
 } from "../ui/summary.js";
 import { createSymbols } from "../ui/symbols.js";
 import { createTheme } from "../ui/theme.js";
 import { discoverProject } from "../utils/discover.js";
 import { getChangedFiles, getStagedFiles } from "../utils/git.js";
 import { appendHistory } from "../utils/history.js";
-import { filterProjectFiles, listProjectFiles } from "../utils/source-files.js";
-import { isCiEnv } from "../telemetry/env.js";
-import { type EngineCounts, withCommandLifecycle } from "../telemetry/index.js";
+import {
+	filterProjectFiles,
+	listProjectFiles,
+	readAislopIgnorePatterns,
+} from "../utils/source-files.js";
+import { applySuppressions } from "../utils/suppress.js";
 import { APP_VERSION } from "../version.js";
 
 interface ScanOptions {
@@ -236,20 +241,22 @@ const runScanBody = async (
 	const machineOutput = isMachineOutput(options);
 	const useLiveProgress = !machineOutput && shouldUseSpinner();
 
+	const excludePatterns = [...config.exclude, ...readAislopIgnorePatterns(resolvedDir)];
+
 	let files: string[] | undefined;
 	if (options.staged) {
-		files = filterProjectFiles(resolvedDir, getStagedFiles(resolvedDir), [], config.exclude);
+		files = filterProjectFiles(resolvedDir, getStagedFiles(resolvedDir), [], excludePatterns);
 		if (!machineOutput) {
 			log.muted(`Scope: ${files.length} staged file(s)`);
 		}
 	} else if (options.changes) {
-		files = filterProjectFiles(resolvedDir, getChangedFiles(resolvedDir), [], config.exclude);
+		files = filterProjectFiles(resolvedDir, getChangedFiles(resolvedDir), [], excludePatterns);
 		if (!machineOutput) {
 			log.muted(`Scope: ${files.length} changed file(s)`);
 		}
 	} else {
 		const allFiles = listProjectFiles(resolvedDir);
-		files = filterProjectFiles(resolvedDir, allFiles, [], config.exclude);
+		files = filterProjectFiles(resolvedDir, allFiles, [], excludePatterns);
 		if (!machineOutput) {
 			log.muted(`Scope: ${files.length} file(s) after exclusions`);
 		}
@@ -317,10 +324,14 @@ const runScanBody = async (
 	);
 	progressRenderer?.stop();
 
-	const results = rawResults.map((result) => ({
+	const severityAdjusted = rawResults.map((result) => ({
 		...result,
 		diagnostics: applyRuleSeverities(result.diagnostics, config.rules),
 	}));
+	const { results, suppressedCount } = applySuppressions(severityAdjusted, resolvedDir);
+	if (suppressedCount > 0 && !machineOutput) {
+		log.muted(`Suppressed ${suppressedCount} finding(s) via aislop-ignore directives`);
+	}
 
 	const allDiagnostics = results.flatMap((r) => r.diagnostics);
 	const elapsedMs = performance.now() - startTime;

--- a/src/engines/ai-slop/comment-blocks.ts
+++ b/src/engines/ai-slop/comment-blocks.ts
@@ -1,3 +1,4 @@
+import { isAislopDirectiveLine } from "../../utils/suppress.js";
 import { MEANINGFUL_JSDOC_TAGS } from "./narrative-comments-patterns.js";
 
 export type BlockKind = "line" | "jsdoc";
@@ -46,6 +47,7 @@ export const getCommentSyntax = (ext: string): { linePrefixes: string[] } | null
 
 const getMatchedLinePrefix = (line: string, syntax: { linePrefixes: string[] }): string | null => {
 	const trimmed = line.trimStart();
+	if (isAislopDirectiveLine(trimmed)) return null;
 	for (const prefix of syntax.linePrefixes) {
 		if (!trimmed.startsWith(prefix)) continue;
 		if (prefix === "#" && trimmed.startsWith("#!")) return null;

--- a/src/utils/source-files.ts
+++ b/src/utils/source-files.ts
@@ -1,7 +1,7 @@
 import { spawnSync } from "node:child_process";
-import micromatch from "micromatch";
 import fs from "node:fs";
 import path from "node:path";
+import micromatch from "micromatch";
 import type { EngineContext } from "../engines/types.js";
 
 const MAX_BUFFER = 50 * 1024 * 1024;
@@ -220,6 +220,20 @@ export const listProjectFiles = (rootDirectory: string): string[] => {
 		.split("\n")
 		.filter((file) => file.length > 0)
 		.map((file) => file.replace(/^\.\//, ""));
+};
+
+export const readAislopIgnorePatterns = (rootDirectory: string): string[] => {
+	const ignorePath = path.join(rootDirectory, ".aislopignore");
+	if (!fs.existsSync(ignorePath)) return [];
+	try {
+		return fs
+			.readFileSync(ignorePath, "utf-8")
+			.split(/\r?\n/)
+			.map((line) => line.trim())
+			.filter((line) => line.length > 0 && !line.startsWith("#"));
+	} catch {
+		return [];
+	}
 };
 
 const normalizeExcludePatterns = (patterns: string[]): string[] => {

--- a/src/utils/suppress.ts
+++ b/src/utils/suppress.ts
@@ -2,7 +2,9 @@ import fs from "node:fs";
 import path from "node:path";
 import type { Diagnostic, EngineResult } from "../engines/types.js";
 
-const DIRECTIVE_RE = /aislop-ignore-(next-line|line|file)\b([^\n]*)/;
+// Require a comment marker before the directive so the bare words in a string
+// literal or doc text don't silently suppress diagnostics for the whole file.
+const DIRECTIVE_RE = /(?:\/\/|\/\*|#|<!--|\*)\s*aislop-ignore-(next-line|line|file)\b([^\n]*)/;
 
 export const isAislopDirectiveLine = (line: string): boolean => DIRECTIVE_RE.test(line);
 

--- a/src/utils/suppress.ts
+++ b/src/utils/suppress.ts
@@ -1,0 +1,93 @@
+import fs from "node:fs";
+import path from "node:path";
+import type { Diagnostic, EngineResult } from "../engines/types.js";
+
+const DIRECTIVE_RE = /aislop-ignore-(next-line|line|file)\b([^\n]*)/;
+
+export const isAislopDirectiveLine = (line: string): boolean => DIRECTIVE_RE.test(line);
+
+type SuppressScope = "next-line" | "line" | "file";
+
+interface Directive {
+	rules: Set<string>;
+	all: boolean;
+}
+
+interface FileDirectives {
+	file: Directive[];
+	byLine: Map<number, Directive[]>;
+}
+
+const parseDirective = (rest: string): Directive => {
+	const beforeReason = rest.split("--")[0];
+	const tokens = beforeReason.match(/[A-Za-z0-9@][\w@/.-]*/g) ?? [];
+	if (tokens.length === 0) return { rules: new Set(), all: true };
+	return { rules: new Set(tokens), all: false };
+};
+
+const covers = (directive: Directive, rule: string): boolean =>
+	directive.all || [...directive.rules].some((r) => r === rule || rule.endsWith(`/${r}`));
+
+const parseFileDirectives = (content: string): FileDirectives => {
+	const lines = content.split(/\r?\n/);
+	const file: Directive[] = [];
+	const byLine = new Map<number, Directive[]>();
+	const addLine = (target: number, directive: Directive) => {
+		const list = byLine.get(target) ?? [];
+		list.push(directive);
+		byLine.set(target, list);
+	};
+	for (let i = 0; i < lines.length; i++) {
+		const match = DIRECTIVE_RE.exec(lines[i]);
+		if (!match) continue;
+		const scope = match[1] as SuppressScope;
+		const directive = parseDirective(match[2] ?? "");
+		if (scope === "file") file.push(directive);
+		else if (scope === "next-line") addLine(i + 2, directive);
+		else addLine(i + 1, directive);
+	}
+	return { file, byLine };
+};
+
+export const applySuppressions = (
+	results: EngineResult[],
+	rootDirectory: string,
+): { results: EngineResult[]; suppressedCount: number } => {
+	const cache = new Map<string, FileDirectives | null>();
+	let suppressedCount = 0;
+
+	const load = (filePath: string): FileDirectives | null => {
+		const cached = cache.get(filePath);
+		if (cached !== undefined) return cached;
+		const absolute = path.isAbsolute(filePath) ? filePath : path.join(rootDirectory, filePath);
+		let parsed: FileDirectives | null = null;
+		try {
+			parsed = parseFileDirectives(fs.readFileSync(absolute, "utf-8"));
+		} catch {
+			parsed = null;
+		}
+		cache.set(filePath, parsed);
+		return parsed;
+	};
+
+	const isSuppressed = (diagnostic: Diagnostic): boolean => {
+		const directives = load(diagnostic.filePath);
+		if (!directives) return false;
+		if (directives.file.some((d) => covers(d, diagnostic.rule))) return true;
+		const onLine = directives.byLine.get(diagnostic.line) ?? [];
+		return onLine.some((d) => covers(d, diagnostic.rule));
+	};
+
+	const filtered = results.map((result) => {
+		const kept = result.diagnostics.filter((diagnostic) => {
+			if (isSuppressed(diagnostic)) {
+				suppressedCount += 1;
+				return false;
+			}
+			return true;
+		});
+		return { ...result, diagnostics: kept };
+	});
+
+	return { results: filtered, suppressedCount };
+};

--- a/tests/source-files.test.ts
+++ b/tests/source-files.test.ts
@@ -4,7 +4,11 @@ import os from "node:os";
 import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { discoverProject } from "../src/utils/discover.js";
-import { filterProjectFiles, getSourceFilesForRoot } from "../src/utils/source-files.js";
+import {
+	filterProjectFiles,
+	getSourceFilesForRoot,
+	readAislopIgnorePatterns,
+} from "../src/utils/source-files.js";
 
 const createFile = (rootDir: string, filePath: string, content = "") => {
 	const absolutePath = path.join(rootDir, filePath);
@@ -137,5 +141,31 @@ describe("source file selection", () => {
 		const sourceFiles = getSourceFilesForRoot(tmpDir).sort();
 
 		expect(sourceFiles).toEqual([path.join(tmpDir, "src/app.ts")]);
+	});
+
+	it("reads .aislopignore patterns, skipping blanks and comments", () => {
+		createFile(tmpDir, ".aislopignore", "# generated code\nlegacy\n\nsrc/api.generated.ts\n");
+
+		expect(readAislopIgnorePatterns(tmpDir)).toEqual(["legacy", "src/api.generated.ts"]);
+	});
+
+	it("excludes files matched by .aislopignore patterns", () => {
+		createFile(tmpDir, ".aislopignore", "legacy\nsrc/api.generated.ts\n");
+		createFile(tmpDir, "src/app.ts", "export const app = true;\n");
+		createFile(tmpDir, "legacy/old.ts", "export const old = true;\n");
+		createFile(tmpDir, "src/api.generated.ts", "export const gen = true;\n");
+
+		const filtered = filterProjectFiles(
+			tmpDir,
+			[
+				path.join(tmpDir, "src/app.ts"),
+				path.join(tmpDir, "legacy/old.ts"),
+				path.join(tmpDir, "src/api.generated.ts"),
+			],
+			[],
+			readAislopIgnorePatterns(tmpDir),
+		);
+
+		expect(filtered).toEqual([path.join(tmpDir, "src/app.ts")]);
 	});
 });

--- a/tests/suppress.test.ts
+++ b/tests/suppress.test.ts
@@ -1,0 +1,141 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { collectBlocks, getCommentSyntax } from "../src/engines/ai-slop/comment-blocks.js";
+import type { Diagnostic, EngineResult } from "../src/engines/types.js";
+import { applySuppressions } from "../src/utils/suppress.js";
+
+let tmpDir: string;
+
+beforeEach(() => {
+	tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "aislop-suppress-"));
+});
+
+afterEach(() => {
+	fs.rmSync(tmpDir, { recursive: true, force: true });
+});
+
+const write = (relativePath: string, content: string) => {
+	const absolutePath = path.join(tmpDir, relativePath);
+	fs.mkdirSync(path.dirname(absolutePath), { recursive: true });
+	fs.writeFileSync(absolutePath, content, "utf-8");
+};
+
+const diag = (filePath: string, line: number, rule: string): Diagnostic => ({
+	filePath,
+	engine: "ai-slop",
+	rule,
+	severity: "warning",
+	message: "x",
+	help: "",
+	line,
+	column: 1,
+	category: "AI Slop",
+	fixable: false,
+});
+
+const wrap = (diagnostics: Diagnostic[]): EngineResult[] => [
+	{ engine: "ai-slop", diagnostics, elapsed: 0, skipped: false },
+];
+
+describe("applySuppressions", () => {
+	it("suppresses the next line for a bare directive", () => {
+		write("a.ts", "// aislop-ignore-next-line\nconst x = {} || {};\nconst y = 1;\n");
+		const { results, suppressedCount } = applySuppressions(
+			wrap([diag("a.ts", 2, "ai-slop/empty-fallback"), diag("a.ts", 3, "ai-slop/other")]),
+			tmpDir,
+		);
+		expect(suppressedCount).toBe(1);
+		expect(results[0].diagnostics.map((d) => d.line)).toEqual([3]);
+	});
+
+	it("only suppresses the named rule when one is given", () => {
+		write("a.ts", "// aislop-ignore-next-line ai-slop/empty-fallback\nconst x = 1;\n");
+		const { results, suppressedCount } = applySuppressions(
+			wrap([diag("a.ts", 2, "ai-slop/empty-fallback"), diag("a.ts", 2, "ai-slop/other")]),
+			tmpDir,
+		);
+		expect(suppressedCount).toBe(1);
+		expect(results[0].diagnostics.map((d) => d.rule)).toEqual(["ai-slop/other"]);
+	});
+
+	it("matches a bare rule name against the engine-prefixed rule", () => {
+		write("a.ts", "// aislop-ignore-next-line empty-fallback\nconst x = 1;\n");
+		const { suppressedCount } = applySuppressions(
+			wrap([diag("a.ts", 2, "ai-slop/empty-fallback")]),
+			tmpDir,
+		);
+		expect(suppressedCount).toBe(1);
+	});
+
+	it("ignores a reason after the -- separator", () => {
+		write(
+			"a.ts",
+			"// aislop-ignore-next-line ai-slop/empty-fallback -- intentional guard\nconst x = 1;\n",
+		);
+		const { suppressedCount } = applySuppressions(
+			wrap([diag("a.ts", 2, "ai-slop/empty-fallback")]),
+			tmpDir,
+		);
+		expect(suppressedCount).toBe(1);
+	});
+
+	it("suppresses on the same line via aislop-ignore-line", () => {
+		write("a.ts", "const x = {} || {}; // aislop-ignore-line\n");
+		const { suppressedCount } = applySuppressions(
+			wrap([diag("a.ts", 1, "ai-slop/empty-fallback")]),
+			tmpDir,
+		);
+		expect(suppressedCount).toBe(1);
+	});
+
+	it("suppresses a whole file with aislop-ignore-file", () => {
+		write("a.ts", "// aislop-ignore-file ai-slop/empty-fallback\nconst a = 1;\nconst b = 2;\n");
+		const { suppressedCount } = applySuppressions(
+			wrap([
+				diag("a.ts", 2, "ai-slop/empty-fallback"),
+				diag("a.ts", 3, "ai-slop/empty-fallback"),
+				diag("a.ts", 3, "ai-slop/other"),
+			]),
+			tmpDir,
+		);
+		expect(suppressedCount).toBe(2);
+	});
+
+	it("works with non-slash comment syntax (python hash)", () => {
+		write("a.py", "# aislop-ignore-next-line\nx = 1\n");
+		const { suppressedCount } = applySuppressions(
+			wrap([diag("a.py", 2, "ai-slop/something")]),
+			tmpDir,
+		);
+		expect(suppressedCount).toBe(1);
+	});
+
+	it("does not suppress unrelated lines and counts nothing when absent", () => {
+		write("a.ts", "const x = 1;\nconst y = 2;\n");
+		const { results, suppressedCount } = applySuppressions(
+			wrap([diag("a.ts", 1, "ai-slop/other")]),
+			tmpDir,
+		);
+		expect(suppressedCount).toBe(0);
+		expect(results[0].diagnostics).toHaveLength(1);
+	});
+});
+
+describe("aislop directive lines are invisible to comment blocks", () => {
+	it("excludes a directive line so the comment below forms its own block", () => {
+		const syntax = getCommentSyntax(".ts");
+		if (!syntax) throw new Error("expected .ts comment syntax");
+		const lines = [
+			"// aislop-ignore-next-line ai-slop/narrative-comment",
+			"// real comment line one",
+			"// real comment line two",
+			"export const x = 1;",
+		];
+		const blocks = collectBlocks(lines, syntax);
+		expect(blocks).toHaveLength(1);
+		expect(blocks[0].startLine).toBe(2);
+		expect(blocks[0].rawLines).toHaveLength(2);
+	});
+});

--- a/tests/suppress.test.ts
+++ b/tests/suppress.test.ts
@@ -121,6 +121,15 @@ describe("applySuppressions", () => {
 		expect(suppressedCount).toBe(0);
 		expect(results[0].diagnostics).toHaveLength(1);
 	});
+
+	it("ignores the directive words inside a string literal (no comment marker)", () => {
+		write("a.ts", 'const help = "pass aislop-ignore-file to skip a file";\nconst y = 2;\n');
+		const { suppressedCount } = applySuppressions(
+			wrap([diag("a.ts", 1, "ai-slop/other"), diag("a.ts", 2, "ai-slop/other")]),
+			tmpDir,
+		);
+		expect(suppressedCount).toBe(0);
+	});
 });
 
 describe("aislop directive lines are invisible to comment blocks", () => {


### PR DESCRIPTION
## What

A first-class suppression mechanism, so a finding you have judged intentional can be silenced without turning a rule off globally.

### Inline directives

```ts
// aislop-ignore-next-line ai-slop/empty-fallback -- options validated upstream
const opts = { ...defaults, ...(input || {}) };

const legacy = doThing(); // aislop-ignore-line
```

- `aislop-ignore-next-line [rule...]` — the line below
- `aislop-ignore-line [rule...]` — the line it sits on
- `aislop-ignore-file [rule...]` — the whole file (place anywhere in it)
- Rule ids are optional: omit them to silence every rule on that line; name one or more (bare `empty-fallback` or fully-qualified `ai-slop/empty-fallback`) to scope it.
- A human reason can follow `--` and is ignored by the matcher.
- Works in any comment syntax (`//`, `#`, `<!-- -->`).

### `.aislopignore`

A root-level ignore file to keep whole paths out of every scan, reusing the same glob semantics as the `exclude` config (with `#` comments):

```
src/generated
**/*.snap
legacy
```

## How

- `applySuppressions` runs after severity adjustment and before scoring, filtering each engine's diagnostics and returning a suppressed count that the run reports.
- `.aislopignore` patterns are merged into the exclude set passed to `filterProjectFiles`.
- Directive lines are made invisible to the comment engines (via `collectBlocks`), so a directive placed directly above a comment-based finding does not join the comment block (which would shift the reported line onto the directive) and is not itself flagged.

## Tests

- `tests/suppress.test.ts` — next-line / same-line / file scope, rule scoping, bare-vs-qualified rule match, `--` reason, non-slash comment syntax, no-op when absent, and the directive-line-as-block-boundary regression.
- `tests/source-files.test.ts` — `.aislopignore` parsing (skips blanks/comments) and path exclusion.
- Full suite green (987 passing).
