### PR TITLE
fix(security): no-downgrade guard on dep fixes + collapse transitive CVEs to root

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Fixed
+
+- **No-downgrade guard on dependency fixes.** `aislop fix -f` no longer writes a dependency override that pins a package below the version already installed. Before applying npm/pnpm overrides it reads the installed version and drops any that would be a downgrade, reporting them as "skipped downgrade(s), verify intent" instead of silently regressing a dependency the way `npm audit fix --force` does.
+- **CVE root-cause collapse.** The dependency audit now attributes a transitive vulnerability to the package that actually carries the advisory rather than emitting a near-duplicate finding for every intermediate package in the chain, so one root CVE reads as one issue instead of ten.
+
 ## 0.10.1 (2026-05-30)
 
 An accuracy release across Python and TypeScript, plus a small quality-of-life feature. The Python function detector was only seeing single-line synchronous `def`s, so async functions and wrapped multi-line signatures (about 58% of a large library like python-telegram-bot) were invisible to the complexity rules. In TypeScript, text-pattern rules were matching code inside JSDoc `@example` blocks as if it were live source. Both are fixed, and the complexity metrics were sharpened to measure real complexity rather than documentation or optional API surface.

--- a/src/commands/fix-expo.ts
+++ b/src/commands/fix-expo.ts
@@ -1,0 +1,64 @@
+import type { EngineContext } from "../engines/types.js";
+import { runSubprocess } from "../utils/subprocess.js";
+
+const INSTALL_TIMEOUT = 30 * 60 * 1000;
+
+export const fixExpoDependencies = async (
+	context: EngineContext,
+	onProgress?: (label: string) => void,
+): Promise<void> => {
+	await removeDisallowedExpoPackages(context.rootDirectory, onProgress);
+
+	onProgress?.("Expo dependency alignment · running expo install --fix (can take a few minutes)");
+	const fixResult = await runSubprocess("npx", ["--yes", "expo", "install", "--fix"], {
+		cwd: context.rootDirectory,
+		timeout: INSTALL_TIMEOUT,
+	});
+
+	if (fixResult.exitCode === 0) return;
+
+	onProgress?.("Expo dependency alignment · checking remaining issues");
+	const checkResult = await runSubprocess("npx", ["--yes", "expo", "install", "--check"], {
+		cwd: context.rootDirectory,
+		timeout: INSTALL_TIMEOUT,
+	});
+
+	if (checkResult.exitCode !== 0) {
+		throw new Error(checkResult.stderr || checkResult.stdout || "expo dependency check failed");
+	}
+};
+
+/**
+ * Run expo-doctor to detect packages that should not be installed directly,
+ * then uninstall them. No hardcoded list — expo-doctor is the source of truth.
+ */
+const removeDisallowedExpoPackages = async (
+	rootDir: string,
+	onProgress?: (label: string) => void,
+): Promise<void> => {
+	try {
+		onProgress?.("Expo dependency alignment · running expo-doctor");
+		const result = await runSubprocess("npx", ["--yes", "expo-doctor", rootDir], {
+			cwd: rootDir,
+			timeout: INSTALL_TIMEOUT,
+		});
+		const output = [result.stdout, result.stderr].filter(Boolean).join("\n");
+
+		const packagePattern = /The package "([^"]+)" should not be installed directly/g;
+		const toRemove: string[] = [];
+		let match: RegExpExecArray | null;
+		while ((match = packagePattern.exec(output)) !== null) {
+			toRemove.push(match[1]);
+		}
+
+		if (toRemove.length === 0) return;
+
+		onProgress?.(`Expo dependency alignment · uninstalling ${toRemove.length} package(s)`);
+		await runSubprocess("npm", ["uninstall", ...toRemove], {
+			cwd: rootDir,
+			timeout: INSTALL_TIMEOUT,
+		});
+	} catch {
+		// Best-effort — don't fail the step
+	}
+};

--- a/src/commands/fix-force.ts
+++ b/src/commands/fix-force.ts
@@ -204,7 +204,10 @@ const tryNpmOverrides = async (
 			| undefined;
 		if (!vulnerabilities) return;
 
-		const overrides = await collectOverrides(rootDir, vulnerabilities, "npm");
+		const rawOverrides = await collectOverrides(rootDir, vulnerabilities, "npm");
+		if (Object.keys(rawOverrides).length === 0) return;
+
+		const overrides = guardAndReport(rootDir, rawOverrides, onProgress);
 		if (Object.keys(overrides).length === 0) return;
 
 		const pkgPath = path.join(rootDir, "package.json");
@@ -257,6 +260,60 @@ export const collectPnpmOverrides = (
 	return overrides;
 };
 
+const overrideName = (key: string): string => {
+	const at = key.lastIndexOf("@");
+	return at > 0 ? key.slice(0, at) : key;
+};
+
+// A "fix" that pins a package below what is already installed is a regression, not
+// a fix, so drop it and let the caller flag it for the human to verify intent.
+export const guardOverrides = (
+	overrides: Record<string, string>,
+	installed: Map<string, string>,
+): { safe: Record<string, string>; skipped: string[] } => {
+	const safe: Record<string, string> = {};
+	const skipped: string[] = [];
+	for (const [key, target] of Object.entries(overrides)) {
+		const current = installed.get(overrideName(key));
+		if (current && isDowngrade(current, target)) {
+			skipped.push(`${overrideName(key)} ${current} → ${target}`);
+			continue;
+		}
+		safe[key] = target;
+	}
+	return { safe, skipped };
+};
+
+const readInstalledVersions = (rootDir: string, names: string[]): Map<string, string> => {
+	const map = new Map<string, string>();
+	for (const name of names) {
+		try {
+			const manifest = path.join(rootDir, "node_modules", name, "package.json");
+			const version = (JSON.parse(fs.readFileSync(manifest, "utf-8")) as { version?: unknown })
+				.version;
+			if (typeof version === "string") map.set(name, version);
+		} catch {
+			// not resolvable on disk — leave unguarded rather than block a real fix
+		}
+	}
+	return map;
+};
+
+const guardAndReport = (
+	rootDir: string,
+	rawOverrides: Record<string, string>,
+	onProgress?: (label: string) => void,
+): Record<string, string> => {
+	const installed = readInstalledVersions(rootDir, Object.keys(rawOverrides).map(overrideName));
+	const { safe, skipped } = guardOverrides(rawOverrides, installed);
+	if (skipped.length > 0) {
+		onProgress?.(
+			`Dependency audit fixes · skipped ${skipped.length} downgrade(s), verify intent: ${skipped.join(", ")}`,
+		);
+	}
+	return safe;
+};
+
 // Detects the retired pnpm audit endpoint (HTTP 410) or other signals that
 // pnpm's audit registry call failed, so callers can fall back to npm.
 const isPnpmAuditRetired = (stdout: string, stderr: string): boolean => {
@@ -307,7 +364,10 @@ const tryPnpmOverrides = async (
 	const advisories = parsed.advisories as Record<string, PnpmAdvisory> | undefined;
 	if (!advisories || Object.keys(advisories).length === 0) return true;
 
-	const overrides = collectPnpmOverrides(advisories);
+	const rawOverrides = collectPnpmOverrides(advisories);
+	if (Object.keys(rawOverrides).length === 0) return true;
+
+	const overrides = guardAndReport(rootDir, rawOverrides, onProgress);
 	if (Object.keys(overrides).length === 0) return true;
 
 	const pkgPath = path.join(rootDir, "package.json");
@@ -323,64 +383,4 @@ const tryPnpmOverrides = async (
 		timeout: INSTALL_TIMEOUT,
 	});
 	return true;
-};
-
-export const fixExpoDependencies = async (
-	context: EngineContext,
-	onProgress?: (label: string) => void,
-): Promise<void> => {
-	await removeDisallowedExpoPackages(context.rootDirectory, onProgress);
-
-	onProgress?.("Expo dependency alignment · running expo install --fix (can take a few minutes)");
-	const fixResult = await runSubprocess("npx", ["--yes", "expo", "install", "--fix"], {
-		cwd: context.rootDirectory,
-		timeout: INSTALL_TIMEOUT,
-	});
-
-	if (fixResult.exitCode === 0) return;
-
-	onProgress?.("Expo dependency alignment · checking remaining issues");
-	const checkResult = await runSubprocess("npx", ["--yes", "expo", "install", "--check"], {
-		cwd: context.rootDirectory,
-		timeout: INSTALL_TIMEOUT,
-	});
-
-	if (checkResult.exitCode !== 0) {
-		throw new Error(checkResult.stderr || checkResult.stdout || "expo dependency check failed");
-	}
-};
-
-/**
- * Run expo-doctor to detect packages that should not be installed directly,
- * then uninstall them. No hardcoded list — expo-doctor is the source of truth.
- */
-const removeDisallowedExpoPackages = async (
-	rootDir: string,
-	onProgress?: (label: string) => void,
-): Promise<void> => {
-	try {
-		onProgress?.("Expo dependency alignment · running expo-doctor");
-		const result = await runSubprocess("npx", ["--yes", "expo-doctor", rootDir], {
-			cwd: rootDir,
-			timeout: INSTALL_TIMEOUT,
-		});
-		const output = [result.stdout, result.stderr].filter(Boolean).join("\n");
-
-		const packagePattern = /The package "([^"]+)" should not be installed directly/g;
-		const toRemove: string[] = [];
-		let match: RegExpExecArray | null;
-		while ((match = packagePattern.exec(output)) !== null) {
-			toRemove.push(match[1]);
-		}
-
-		if (toRemove.length === 0) return;
-
-		onProgress?.(`Expo dependency alignment · uninstalling ${toRemove.length} package(s)`);
-		await runSubprocess("npm", ["uninstall", ...toRemove], {
-			cwd: rootDir,
-			timeout: INSTALL_TIMEOUT,
-		});
-	} catch {
-		// Best-effort — don't fail the step
-	}
 };

--- a/src/commands/fix-force.ts
+++ b/src/commands/fix-force.ts
@@ -284,17 +284,56 @@ export const guardOverrides = (
 	return { safe, skipped };
 };
 
-const readInstalledVersions = (rootDir: string, names: string[]): Map<string, string> => {
+const readRootNodeModulesVersion = (rootDir: string, name: string): string | null => {
+	try {
+		const manifest = path.join(rootDir, "node_modules", name, "package.json");
+		const version = (JSON.parse(fs.readFileSync(manifest, "utf-8")) as { version?: unknown })
+			.version;
+		return typeof version === "string" ? version : null;
+	} catch {
+		return null;
+	}
+};
+
+const PNPM_STORE_VERSION_RE = /^(\d+\.\d+\.\d+[^_(]*)/;
+
+const isHigherVersion = (candidate: string, current: string | null): boolean => {
+	if (!current) return true;
+	const a = parseSemverMin(candidate);
+	const b = parseSemverMin(current);
+	if (!a || !b) return false;
+	for (let i = 0; i < 3; i++) {
+		if ((a[i] ?? 0) > (b[i] ?? 0)) return true;
+		if ((a[i] ?? 0) < (b[i] ?? 0)) return false;
+	}
+	return false;
+};
+
+// pnpm stores non-hoisted packages as node_modules/.pnpm/<name>@<version> (scoped
+// slash becomes a plus); take the highest version since pinning below it downgrades.
+const readPnpmStoreVersion = (rootDir: string, name: string): string | null => {
+	let entries: string[];
+	try {
+		entries = fs.readdirSync(path.join(rootDir, "node_modules", ".pnpm"));
+	} catch {
+		return null;
+	}
+	const prefix = `${name.replace(/\//g, "+")}@`;
+	let best: string | null = null;
+	for (const entry of entries) {
+		if (!entry.startsWith(prefix)) continue;
+		const match = PNPM_STORE_VERSION_RE.exec(entry.slice(prefix.length));
+		if (match && isHigherVersion(match[1], best)) best = match[1];
+	}
+	return best;
+};
+
+export const readInstalledVersions = (rootDir: string, names: string[]): Map<string, string> => {
 	const map = new Map<string, string>();
 	for (const name of names) {
-		try {
-			const manifest = path.join(rootDir, "node_modules", name, "package.json");
-			const version = (JSON.parse(fs.readFileSync(manifest, "utf-8")) as { version?: unknown })
-				.version;
-			if (typeof version === "string") map.set(name, version);
-		} catch {
-			// not resolvable on disk — leave unguarded rather than block a real fix
-		}
+		const version =
+			readRootNodeModulesVersion(rootDir, name) ?? readPnpmStoreVersion(rootDir, name);
+		if (version) map.set(name, version);
 	}
 	return map;
 };

--- a/src/commands/fix-pipeline.ts
+++ b/src/commands/fix-pipeline.ts
@@ -4,8 +4,8 @@ import { detectDeadPatterns } from "../engines/ai-slop/dead-patterns.js";
 import { fixDeadPatterns } from "../engines/ai-slop/dead-patterns-fix.js";
 import { detectDuplicateImports } from "../engines/ai-slop/duplicate-imports.js";
 import { fixDuplicateImports } from "../engines/ai-slop/duplicate-imports-fix.js";
-import { fixNarrativeComments } from "../engines/ai-slop/narrative-comments-fix.js";
 import { detectNarrativeComments } from "../engines/ai-slop/narrative-comments.js";
+import { fixNarrativeComments } from "../engines/ai-slop/narrative-comments-fix.js";
 import { detectUnusedImports } from "../engines/ai-slop/unused-imports.js";
 import { fixUnusedImports } from "../engines/ai-slop/unused-imports-fix.js";
 import {
@@ -24,14 +24,15 @@ import { fixGenericFormatter, runGenericFormatter } from "../engines/format/gene
 import { fixGofmt, runGofmt } from "../engines/format/gofmt.js";
 import { fixRuffFormat, runRuffFormat } from "../engines/format/ruff-format.js";
 import { runExpoDoctor } from "../engines/lint/expo-doctor.js";
-import { fixOxlint, runOxlint } from "../engines/lint/oxlint.js";
 import { fixRubyLint } from "../engines/lint/generic.js";
+import { fixOxlint, runOxlint } from "../engines/lint/oxlint.js";
 import { fixRuffLint, fixRuffLintForce, runRuffLint } from "../engines/lint/ruff.js";
 import { runDependencyAudit } from "../engines/security/audit.js";
 import type { Diagnostic, EngineContext } from "../engines/types.js";
 import { log } from "../ui/logger.js";
 import type { discoverProject } from "../utils/discover.js";
-import { fixDependencyAudit, fixExpoDependencies } from "./fix-force.js";
+import { fixExpoDependencies } from "./fix-expo.js";
+import { fixDependencyAudit } from "./fix-force.js";
 import type { FixStepResult } from "./fix-steps.js";
 
 export type ProjectInfo = Awaited<ReturnType<typeof discoverProject>>;

--- a/src/engines/security/audit.ts
+++ b/src/engines/security/audit.ts
@@ -200,13 +200,21 @@ const parseLegacyAdvisories = (
 	return [...bucket.values()].map((agg) => aggregateToDiagnostic(agg, source));
 };
 
+// An object in `via` means this package is the CVE source; a string means it is
+// only affected through another, so reporting it would duplicate the root cause.
+const carriesAdvisory = (vulnerability: Record<string, unknown>): boolean =>
+	Array.isArray(vulnerability.via) &&
+	vulnerability.via.some((entry) => entry !== null && typeof entry === "object");
+
 const parseModernVulnerabilities = (
 	vulnerabilities: Record<string, Record<string, unknown>>,
 	source: JsAuditSource,
 ): Diagnostic[] => {
 	const bucket = new Map<string, VulnAggregate>();
+	const hasRootCauses = Object.values(vulnerabilities).some(carriesAdvisory);
 
 	for (const [packageName, vulnerability] of Object.entries(vulnerabilities)) {
+		if (hasRootCauses && !carriesAdvisory(vulnerability)) continue;
 		const severity = ((vulnerability.severity as string) ?? "moderate").toLowerCase();
 		const fixAvailable = vulnerability.fixAvailable;
 		const isDirect = vulnerability.isDirect === true;
@@ -236,7 +244,7 @@ const parseModernVulnerabilities = (
 	return [...bucket.values()].map((agg) => aggregateToDiagnostic(agg, source));
 };
 
-const parseJsAudit = (output: string, source: JsAuditSource): Diagnostic[] => {
+export const parseJsAudit = (output: string, source: JsAuditSource): Diagnostic[] => {
 	if (!output) return [];
 	try {
 		const parsed = JSON.parse(output) as Record<string, unknown>;

--- a/tests/audit-parse.test.ts
+++ b/tests/audit-parse.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, it } from "vitest";
+import { parseJsAudit } from "../src/engines/security/audit.js";
+
+describe("parseJsAudit — modern vulnerabilities", () => {
+	it("collapses a transitive chain to the package that carries the advisory", () => {
+		const audit = JSON.stringify({
+			vulnerabilities: {
+				uuid: {
+					name: "uuid",
+					severity: "high",
+					isDirect: false,
+					range: "<7.0.0",
+					fixAvailable: { name: "uuid", version: "7.0.0" },
+					via: [
+						{
+							source: 1,
+							name: "uuid",
+							title: "Insecure randomness in uuid",
+							severity: "high",
+							range: "<7.0.0",
+						},
+					],
+				},
+				firebase: {
+					name: "firebase",
+					severity: "high",
+					isDirect: true,
+					range: "*",
+					fixAvailable: false,
+					via: ["uuid"],
+				},
+				"@firebase/auth": {
+					name: "@firebase/auth",
+					severity: "high",
+					isDirect: false,
+					range: "*",
+					fixAvailable: false,
+					via: ["firebase"],
+				},
+			},
+		});
+
+		const diagnostics = parseJsAudit(audit, "npm audit");
+
+		expect(diagnostics).toHaveLength(1);
+		expect(diagnostics[0].message).toContain("uuid");
+		expect(diagnostics[0].rule).toBe("security/vulnerable-dependency");
+	});
+
+	it("reports every package when none carry an advisory object (no root info)", () => {
+		const audit = JSON.stringify({
+			vulnerabilities: {
+				a: { name: "a", severity: "low", via: ["b"], fixAvailable: false, range: "*" },
+				b: { name: "b", severity: "low", via: ["a"], fixAvailable: false, range: "*" },
+			},
+		});
+
+		const diagnostics = parseJsAudit(audit, "npm audit");
+
+		expect(diagnostics).toHaveLength(2);
+	});
+
+	it("keeps multiple distinct root advisories", () => {
+		const audit = JSON.stringify({
+			vulnerabilities: {
+				uuid: {
+					name: "uuid",
+					severity: "high",
+					via: [{ source: 1, name: "uuid", title: "x", severity: "high", range: "<7" }],
+					fixAvailable: false,
+					range: "<7",
+				},
+				lodash: {
+					name: "lodash",
+					severity: "critical",
+					via: [{ source: 2, name: "lodash", title: "y", severity: "critical", range: "<4.17.21" }],
+					fixAvailable: false,
+					range: "<4.17.21",
+				},
+				express: {
+					name: "express",
+					severity: "high",
+					via: ["lodash"],
+					fixAvailable: false,
+					range: "*",
+				},
+			},
+		});
+
+		const diagnostics = parseJsAudit(audit, "npm audit");
+
+		expect(diagnostics).toHaveLength(2);
+		expect(diagnostics.map((d) => d.message).join(" ")).toContain("uuid");
+		expect(diagnostics.map((d) => d.message).join(" ")).toContain("lodash");
+	});
+});

--- a/tests/fix-force.test.ts
+++ b/tests/fix-force.test.ts
@@ -1,11 +1,12 @@
 import { describe, expect, it } from "vitest";
 import {
 	collectPnpmOverrides,
+	guardOverrides,
 	isDowngrade,
 	overrideKey,
+	type PnpmAdvisory,
 	parseSemverMin,
 	patchedRangeToVersion,
-	type PnpmAdvisory,
 } from "../src/commands/fix-force.js";
 
 describe("patchedRangeToVersion", () => {
@@ -137,5 +138,34 @@ describe("isDowngrade", () => {
 	it("returns false when either side is unparseable (no info, do nothing)", () => {
 		expect(isDowngrade("workspace:*", "^1.0.0")).toBe(false);
 		expect(isDowngrade("^1.0.0", "workspace:*")).toBe(false);
+	});
+});
+
+describe("guardOverrides", () => {
+	it("drops an override that pins a package below the installed version", () => {
+		const installed = new Map([["firebase", "7.1.0"]]);
+		const { safe, skipped } = guardOverrides({ "firebase@<4.9.0": "^4.9.0" }, installed);
+		expect(safe).toEqual({});
+		expect(skipped).toEqual(["firebase 7.1.0 → ^4.9.0"]);
+	});
+
+	it("keeps an override that is a genuine upgrade", () => {
+		const installed = new Map([["ajv", "8.10.0"]]);
+		const { safe, skipped } = guardOverrides({ "ajv@<8.18.0": "^8.18.0" }, installed);
+		expect(safe).toEqual({ "ajv@<8.18.0": "^8.18.0" });
+		expect(skipped).toEqual([]);
+	});
+
+	it("applies overrides for packages whose installed version is unknown", () => {
+		const { safe, skipped } = guardOverrides({ "left-pad@<1.3.0": "^1.3.0" }, new Map());
+		expect(safe).toEqual({ "left-pad@<1.3.0": "^1.3.0" });
+		expect(skipped).toEqual([]);
+	});
+
+	it("resolves the package name from a scoped override key", () => {
+		const installed = new Map([["@scope/pkg", "5.0.0"]]);
+		const { safe, skipped } = guardOverrides({ "@scope/pkg@<2.0.0": "^2.0.0" }, installed);
+		expect(safe).toEqual({});
+		expect(skipped).toEqual(["@scope/pkg 5.0.0 → ^2.0.0"]);
 	});
 });

--- a/tests/fix-force.test.ts
+++ b/tests/fix-force.test.ts
@@ -1,4 +1,7 @@
-import { describe, expect, it } from "vitest";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import {
 	collectPnpmOverrides,
 	guardOverrides,
@@ -7,6 +10,7 @@ import {
 	type PnpmAdvisory,
 	parseSemverMin,
 	patchedRangeToVersion,
+	readInstalledVersions,
 } from "../src/commands/fix-force.js";
 
 describe("patchedRangeToVersion", () => {
@@ -167,5 +171,49 @@ describe("guardOverrides", () => {
 		const { safe, skipped } = guardOverrides({ "@scope/pkg@<2.0.0": "^2.0.0" }, installed);
 		expect(safe).toEqual({});
 		expect(skipped).toEqual(["@scope/pkg 5.0.0 → ^2.0.0"]);
+	});
+});
+
+describe("readInstalledVersions", () => {
+	let tmpDir: string;
+
+	const writeManifest = (relDir: string, version: string) => {
+		const dir = path.join(tmpDir, relDir);
+		fs.mkdirSync(dir, { recursive: true });
+		fs.writeFileSync(path.join(dir, "package.json"), JSON.stringify({ version }), "utf-8");
+	};
+
+	beforeEach(() => {
+		tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "aislop-installed-"));
+	});
+
+	afterEach(() => {
+		fs.rmSync(tmpDir, { recursive: true, force: true });
+	});
+
+	it("reads a hoisted package from root node_modules", () => {
+		writeManifest("node_modules/firebase", "7.1.0");
+		expect(readInstalledVersions(tmpDir, ["firebase"]).get("firebase")).toBe("7.1.0");
+	});
+
+	it("falls back to the highest version in pnpm's virtual store", () => {
+		fs.mkdirSync(path.join(tmpDir, "node_modules/.pnpm/uuid@3.4.0/node_modules/uuid"), {
+			recursive: true,
+		});
+		fs.mkdirSync(path.join(tmpDir, "node_modules/.pnpm/uuid@7.0.0_react@18/node_modules/uuid"), {
+			recursive: true,
+		});
+		expect(readInstalledVersions(tmpDir, ["uuid"]).get("uuid")).toBe("7.0.0");
+	});
+
+	it("resolves a scoped package from the pnpm store (slash becomes plus)", () => {
+		fs.mkdirSync(path.join(tmpDir, "node_modules/.pnpm/@scope+pkg@5.0.0/node_modules/@scope/pkg"), {
+			recursive: true,
+		});
+		expect(readInstalledVersions(tmpDir, ["@scope/pkg"]).get("@scope/pkg")).toBe("5.0.0");
+	});
+
+	it("omits packages that are not installed anywhere", () => {
+		expect(readInstalledVersions(tmpDir, ["missing"]).has("missing")).toBe(false);
 	});
 });


### PR DESCRIPTION
## Why

Two corrections to dependency auditing, both surfaced by a field report: a "fix" recommended dropping a dependency several major versions, and a single transitive CVE was reported once per intermediate package (ten findings for one real issue).

## What

### No-downgrade guard (`aislop fix -f`)

The override collectors picked a target version from the advisory but never compared it to what was already installed, so an old advisory could pin a package *below* the current version — a regression dressed up as a fix, the same trap as `npm audit fix --force`.

Now, before writing npm or pnpm overrides, the fixer reads the installed version of each target and drops any override that would be a downgrade, reporting them:

```
Dependency audit fixes · skipped 1 downgrade(s), verify intent: firebase 7.1.0 → ^4.9.0
```

The guard (`guardOverrides` + installed-version read) is shared across the npm and pnpm paths. If the installed version can't be resolved on disk, the override is left to apply rather than block a real fix.

### CVE root-cause collapse (scan)

In npm/pnpm audit v2, a package's `via` lists either advisory objects (this package is the CVE source) or plain package names (it is only affected through another). The parser reported every affected package, turning one root CVE into a chain of near-duplicate findings. It now keeps only the packages that carry an advisory, so the ten intermediate findings collapse into the one root issue (e.g. `uuid`). If no package carries an advisory object, the previous behaviour (report all) is kept.

### Housekeeping

Extracted the Expo dependency-alignment helpers into `fix-expo.ts` to keep `fix-force.ts` within the file-size budget.

## Tests

- `tests/fix-force.test.ts` — `guardOverrides`: drops a downgrade, keeps an upgrade, applies when the installed version is unknown, resolves scoped package names.
- `tests/audit-parse.test.ts` — `parseJsAudit`: collapses a transitive chain to the advisory-carrying root, keeps multiple distinct roots, falls back to reporting all when no root info exists.
- Full suite green.
