### PR TITLE
feat(fix): add --safe mode for reversible-only fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 - **`aislop fix --safe`.** An opt-in mode that restricts the run to fixes that cannot change behaviour — unused-import removal, import merging, narrative-comment removal, and formatting. Anything that deletes code or rewrites behaviour/attributes (console and dead-code removal, lint autofixes, unused-declaration and dependency pruning, and all `-f` force steps) is skipped, so a `--safe` run is genuinely safe to apply and commit. The default `fix` is unchanged.
 
+### Fixed
+
+- **Python comma imports.** The unused-import fixer treated `import os, sys` as a single binding, so one unused module (`os`) deleted the whole line and broke the used one (`sys`). Each comma-separated module is now considered independently: the unused one is trimmed (`import os, sys` → `import sys`), the line is removed only when every module is unused, and a line where all are used is left alone.
+
 ## 0.10.1 (2026-05-30)
 
 An accuracy release across Python and TypeScript, plus a small quality-of-life feature. The Python function detector was only seeing single-line synchronous `def`s, so async functions and wrapped multi-line signatures (about 58% of a large library like python-telegram-bot) were invisible to the complexity rules. In TypeScript, text-pattern rules were matching code inside JSDoc `@example` blocks as if it were live source. Both are fixed, and the complexity metrics were sharpened to measure real complexity rather than documentation or optional API surface.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Added
+
+- **`aislop fix --safe`.** An opt-in mode that restricts the run to fixes that cannot change behaviour — unused-import removal, import merging, narrative-comment removal, and formatting. Anything that deletes code or rewrites behaviour/attributes (console and dead-code removal, lint autofixes, unused-declaration and dependency pruning, and all `-f` force steps) is skipped, so a `--safe` run is genuinely safe to apply and commit. The default `fix` is unchanged.
+
 ## 0.10.1 (2026-05-30)
 
 An accuracy release across Python and TypeScript, plus a small quality-of-life feature. The Python function detector was only seeing single-line synchronous `def`s, so async functions and wrapped multi-line signatures (about 58% of a large library like python-telegram-bot) were invisible to the complexity rules. In TypeScript, text-pattern rules were matching code inside JSDoc `@example` blocks as if it were live source. Both are fixed, and the complexity metrics were sharpened to measure real complexity rather than documentation or optional API surface.

--- a/README.md
+++ b/README.md
@@ -118,9 +118,12 @@ ci:
 Auto-fix what's mechanical (formatters, unused imports, dead code). For issues that need context, hand off to your agent with full diagnostic info.
 
 ```bash
-npx aislop fix                 # safe auto-fixes
+npx aislop fix                 # auto-fixes
+npx aislop fix --safe          # only reversible fixes (imports, comment removal, formatting)
 npx aislop fix -f              # aggressive: deps, unused files
 ```
+
+`--safe` restricts the run to fixes that cannot change behaviour — unused-import removal, import merging, narrative-comment removal, and formatting. Anything that deletes code or rewrites behaviour/attributes (console/dead-code removal, lint autofixes, unused-declaration and dependency pruning) is skipped, so a `--safe` run is genuinely "apply and commit".
 
 ### Hand off to agent
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -214,6 +214,10 @@ const fixProgram = program
 	.description("Auto-fix ai slop in codebase")
 	.option("-d, --verbose", "show detailed fix progress")
 	.option("-f, --force", "run aggressive fixes (audit and framework dependency alignment)")
+	.option(
+		"--safe",
+		"only apply reversible fixes (imports, comment removal, formatting); skip anything that deletes code or rewrites behaviour",
+	)
 	.option("-p, --prompt", "print a prompt for your coding agent to fix remaining issues");
 
 for (const a of FIX_AGENT_FLAGS) fixProgram.option(`--${a.flag}`, a.help);
@@ -223,6 +227,7 @@ fixProgram.action(async (directory = ".", _flags, command) => {
 	await fixCommand(directory, loadConfig(directory), {
 		verbose: Boolean(flags.verbose),
 		force: Boolean(flags.force),
+		safe: Boolean(flags.safe),
 		prompt: Boolean(flags.prompt),
 		agent: matchFixAgent(flags),
 	});

--- a/src/commands/fix-pipeline.ts
+++ b/src/commands/fix-pipeline.ts
@@ -4,8 +4,8 @@ import { detectDeadPatterns } from "../engines/ai-slop/dead-patterns.js";
 import { fixDeadPatterns } from "../engines/ai-slop/dead-patterns-fix.js";
 import { detectDuplicateImports } from "../engines/ai-slop/duplicate-imports.js";
 import { fixDuplicateImports } from "../engines/ai-slop/duplicate-imports-fix.js";
-import { fixNarrativeComments } from "../engines/ai-slop/narrative-comments-fix.js";
 import { detectNarrativeComments } from "../engines/ai-slop/narrative-comments.js";
+import { fixNarrativeComments } from "../engines/ai-slop/narrative-comments-fix.js";
 import { detectUnusedImports } from "../engines/ai-slop/unused-imports.js";
 import { fixUnusedImports } from "../engines/ai-slop/unused-imports-fix.js";
 import {
@@ -24,8 +24,8 @@ import { fixGenericFormatter, runGenericFormatter } from "../engines/format/gene
 import { fixGofmt, runGofmt } from "../engines/format/gofmt.js";
 import { fixRuffFormat, runRuffFormat } from "../engines/format/ruff-format.js";
 import { runExpoDoctor } from "../engines/lint/expo-doctor.js";
-import { fixOxlint, runOxlint } from "../engines/lint/oxlint.js";
 import { fixRubyLint } from "../engines/lint/generic.js";
+import { fixOxlint, runOxlint } from "../engines/lint/oxlint.js";
 import { fixRuffLint, fixRuffLintForce, runRuffLint } from "../engines/lint/ruff.js";
 import { runDependencyAudit } from "../engines/security/audit.js";
 import type { Diagnostic, EngineContext } from "../engines/types.js";
@@ -52,6 +52,8 @@ export interface PipelineDeps {
 	resolvedDir: string;
 	projectInfo: ProjectInfo;
 	force: boolean;
+	// Restrict to reversible fixes only (imports, comment removal, formatting).
+	safe: boolean;
 	runStep: RunStepFn;
 }
 
@@ -72,6 +74,17 @@ export const runAiSlopSteps = async (deps: PipelineDeps): Promise<void> => {
 		() => detectDuplicateImports(deps.context),
 		() => fixDuplicateImports(deps.context),
 	);
+
+	// Dead-pattern removal deletes code (console statements, dead branches), so in
+	// safe mode we keep only narrative-comment removal, which is reversible.
+	if (deps.safe) {
+		await deps.runStep(
+			"Narrative comments",
+			async () => (await detectNarrativeComments(deps.context)).filter((d) => d.fixable),
+			() => fixNarrativeComments(deps.context),
+		);
+		return;
+	}
 
 	const detectFixableSlop = async () => {
 		const [comments, dead, narrative] = await Promise.all([

--- a/src/commands/fix.ts
+++ b/src/commands/fix.ts
@@ -1,18 +1,17 @@
 import fs from "node:fs";
 import path from "node:path";
 import { performance } from "node:perf_hooks";
-import { findConfigDir, RULES_FILE, type AislopConfig } from "../config/index.js";
+import { type AislopConfig, findConfigDir, RULES_FILE } from "../config/index.js";
 import { runEngines } from "../engines/orchestrator.js";
 import type { Diagnostic, EngineConfig, EngineContext } from "../engines/types.js";
 import { calculateScore } from "../scoring/index.js";
-import { style, theme as defaultTheme } from "../ui/theme.js";
+import { withCommandLifecycle } from "../telemetry/index.js";
 import { renderHeader } from "../ui/header.js";
 import { LiveRail } from "../ui/live-rail.js";
 import { log } from "../ui/logger.js";
+import { theme as defaultTheme, style } from "../ui/theme.js";
 import { discoverProject } from "../utils/discover.js";
-import { withCommandLifecycle } from "../telemetry/index.js";
 import { APP_VERSION } from "../version.js";
-import { buildScanRender } from "./scan.js";
 import { launchAgent, printPrompt } from "./fix-code.js";
 import {
 	type PipelineDeps,
@@ -25,12 +24,15 @@ import {
 	runLintSteps,
 } from "./fix-pipeline.js";
 import { describeStep, type FixStepResult, runOneFixStep, statusFor } from "./fix-steps.js";
+import { buildScanRender } from "./scan.js";
 
 export { buildFixRender } from "./fix-render.js";
 
 interface FixOptions {
 	verbose: boolean;
 	force?: boolean;
+	/** Restrict to reversible fixes only (imports, comment removal, formatting) */
+	safe?: boolean;
 	/** Agent CLI to launch with remaining issues (e.g. "claude", "codex") */
 	agent?: string;
 	/** Print the prompt to stdout instead of launching an agent */
@@ -116,20 +118,25 @@ const runFixBody = async (
 		return result;
 	};
 
+	const safe = Boolean(options.safe);
 	const pipelineDeps: PipelineDeps = {
 		rail,
 		context,
 		config,
 		resolvedDir,
 		projectInfo,
-		force: Boolean(options.force),
+		force: safe ? false : Boolean(options.force),
+		safe,
 		runStep,
 	};
 
 	await runAiSlopSteps(pipelineDeps);
-	await runDeclarationStep(pipelineDeps);
-	await runLintSteps(pipelineDeps);
-	await runDependencyStep(pipelineDeps);
+	// Safe mode skips the steps that delete code or rewrite behaviour/attributes.
+	if (!safe) {
+		await runDeclarationStep(pipelineDeps);
+		await runLintSteps(pipelineDeps);
+		await runDependencyStep(pipelineDeps);
+	}
 
 	await runFormattingStep(pipelineDeps);
 

--- a/src/engines/ai-slop/unused-imports-fix.ts
+++ b/src/engines/ai-slop/unused-imports-fix.ts
@@ -171,7 +171,10 @@ const rewritePyImportLine = (
 ): void => {
 	const line = lines[lineIdx];
 	const fromMatch = line.match(/^(\s*from\s+[\w.]+\s+import\s+)(.+)$/);
-	if (!fromMatch) return;
+	if (!fromMatch) {
+		rewritePlainPyImportLine(lines, lineIdx, unusedNames);
+		return;
+	}
 
 	const prefix = fromMatch[1];
 	const importPart = fromMatch[2].replace(/#.*$/, "").trim();
@@ -189,4 +192,28 @@ const rewritePyImportLine = (
 
 	const joined = keptSpecifiers.join(", ");
 	lines[lineIdx] = hasParen ? `${prefix}(${joined})` : `${prefix}${joined}`;
+};
+
+const rewritePlainPyImportLine = (
+	lines: string[],
+	lineIdx: number,
+	unusedNames: Set<string>,
+): void => {
+	const match = lines[lineIdx].match(/^(\s*import\s+)(.+)$/);
+	if (!match) return;
+
+	const prefix = match[1];
+	const specifiers = match[2]
+		.replace(/#.*$/, "")
+		.split(",")
+		.map((s) => s.trim())
+		.filter(Boolean);
+	const kept = specifiers.filter((spec) => {
+		const parts = spec.split(/\s+as\s+/);
+		const localName = parts.length > 1 ? parts[1].trim() : parts[0].trim().split(".")[0];
+		return !unusedNames.has(localName);
+	});
+
+	if (kept.length === 0 || kept.length === specifiers.length) return;
+	lines[lineIdx] = `${prefix}${kept.join(", ")}`;
 };

--- a/src/engines/ai-slop/unused-imports.ts
+++ b/src/engines/ai-slop/unused-imports.ts
@@ -118,21 +118,27 @@ const extractPyImportedSymbols = (
 			continue;
 		}
 
-		const importMatch = trimmed.match(/^import\s+([\w.]+)(?:\s+as\s+(\w+))?/);
+		const importMatch = trimmed.match(/^import\s+(.+)/);
 		if (importMatch) {
 			importLines.add(i);
-			const alias = importMatch[2];
-			// `import X as X` is also a re-export marker.
-			if (alias && alias === importMatch[1]) continue;
-			const localName = alias ?? importMatch[1];
-			const simpleName = localName.split(".")[0];
-			if (simpleName && /^\w+$/.test(simpleName)) {
-				symbols.push({
-					name: simpleName,
-					line: i + 1,
-					isDefault: false,
-					isNamespace: true,
-				});
+			// `import a, b.c as d` binds each comma-separated clause independently;
+			// capturing only the first would delete the whole line for one unused name.
+			for (const clause of importMatch[1].replace(/#.*$/, "").split(",")) {
+				const clauseMatch = clause.trim().match(/^([\w.]+)(?:\s+as\s+(\w+))?/);
+				if (!clauseMatch) continue;
+				const alias = clauseMatch[2];
+				// `import X as X` is a re-export marker.
+				if (alias && alias === clauseMatch[1]) continue;
+				const localName = alias ?? clauseMatch[1];
+				const simpleName = localName.split(".")[0];
+				if (simpleName && /^\w+$/.test(simpleName)) {
+					symbols.push({
+						name: simpleName,
+						line: i + 1,
+						isDefault: false,
+						isNamespace: true,
+					});
+				}
 			}
 		}
 	}

--- a/tests/fix-safe-mode.test.ts
+++ b/tests/fix-safe-mode.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from "vitest";
+import type { PipelineDeps } from "../src/commands/fix-pipeline.js";
+import { runAiSlopSteps } from "../src/commands/fix-pipeline.js";
+import type { FixStepResult } from "../src/commands/fix-steps.js";
+import type { AislopConfig } from "../src/config/index.js";
+
+const recordingDeps = (safe: boolean): { deps: PipelineDeps; steps: string[] } => {
+	const steps: string[] = [];
+	const runStep: PipelineDeps["runStep"] = async (name) => {
+		steps.push(name);
+		const result: FixStepResult = {
+			name,
+			beforeIssues: 0,
+			afterIssues: 0,
+			resolvedIssues: 0,
+			beforeFiles: 0,
+			failed: false,
+			elapsedMs: 0,
+		};
+		return result;
+	};
+	const deps = {
+		rail: { start: () => {}, setActiveLabel: () => {} },
+		context: {
+			rootDirectory: "/tmp/none",
+			languages: ["typescript"],
+			frameworks: ["none"],
+			files: [],
+			installedTools: {},
+			config: {} as PipelineDeps["context"]["config"],
+		},
+		config: { engines: { "ai-slop": true } } as unknown as AislopConfig,
+		resolvedDir: "/tmp/none",
+		projectInfo: { languages: ["typescript"] } as PipelineDeps["projectInfo"],
+		force: false,
+		safe,
+		runStep,
+	} as PipelineDeps;
+	return { deps, steps };
+};
+
+describe("runAiSlopSteps safe mode", () => {
+	it("runs only reversible steps and the narrative-comment step in safe mode", async () => {
+		const { deps, steps } = recordingDeps(true);
+		await runAiSlopSteps(deps);
+		expect(steps).toEqual(["Unused imports", "Duplicate imports", "Narrative comments"]);
+		expect(steps).not.toContain("Dead code & comments");
+	});
+
+	it("runs the combined dead-code-and-comments step in default mode", async () => {
+		const { deps, steps } = recordingDeps(false);
+		await runAiSlopSteps(deps);
+		expect(steps).toEqual(["Unused imports", "Duplicate imports", "Dead code & comments"]);
+		expect(steps).not.toContain("Narrative comments");
+	});
+});

--- a/tests/unused-imports-py.test.ts
+++ b/tests/unused-imports-py.test.ts
@@ -1,0 +1,60 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { fixUnusedImports } from "../src/engines/ai-slop/unused-imports-fix.js";
+import type { EngineContext } from "../src/engines/types.js";
+
+let tmpDir: string;
+
+const makeContext = (files: string[]): EngineContext => ({
+	rootDirectory: tmpDir,
+	languages: ["python"],
+	frameworks: ["none"],
+	files,
+	installedTools: {},
+	config: {
+		quality: { maxFunctionLoc: 80, maxFileLoc: 400, maxNesting: 4, maxParams: 6 },
+		security: { audit: true, auditTimeout: 25000 },
+	},
+});
+
+const write = (filename: string, content: string): string => {
+	const filePath = path.join(tmpDir, filename);
+	fs.writeFileSync(filePath, content, "utf-8");
+	return filePath;
+};
+
+beforeEach(() => {
+	tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "aislop-unused-py-"));
+});
+
+afterEach(() => {
+	fs.rmSync(tmpDir, { recursive: true, force: true });
+});
+
+describe("fixUnusedImports — Python comma imports", () => {
+	it("trims only the unused module, preserving the rest of the line", async () => {
+		const file = write("m.py", "import os, sys\n\nprint(sys.path)\n");
+		await fixUnusedImports(makeContext([file]));
+		expect(fs.readFileSync(file, "utf-8")).toBe("import sys\n\nprint(sys.path)\n");
+	});
+
+	it("removes the whole line when every module on it is unused", async () => {
+		const file = write("m.py", "import os, sys\n\nx = 1\nprint(x)\n");
+		await fixUnusedImports(makeContext([file]));
+		expect(fs.readFileSync(file, "utf-8")).toBe("x = 1\nprint(x)\n");
+	});
+
+	it("leaves the line untouched when every module is used", async () => {
+		const file = write("m.py", "import os, sys\n\nprint(os.getcwd(), sys.path)\n");
+		await fixUnusedImports(makeContext([file]));
+		expect(fs.readFileSync(file, "utf-8")).toBe("import os, sys\n\nprint(os.getcwd(), sys.path)\n");
+	});
+
+	it("respects an alias as the bound name", async () => {
+		const file = write("m.py", "import os, numpy as np\n\nprint(np.array([1]))\n");
+		await fixUnusedImports(makeContext([file]));
+		expect(fs.readFileSync(file, "utf-8")).toBe("import numpy as np\n\nprint(np.array([1]))\n");
+	});
+});


### PR DESCRIPTION
## Why

The default `aislop fix` includes fixes that can change behaviour (console/dead-code removal, lint autofixes), so "run it and commit" is not always true. A field report asked for a mode that only applies changes a reviewer would accept blind.

## What

`aislop fix --safe` restricts the run to fixes that cannot change behaviour:

- unused-import removal
- import merging (duplicate imports)
- narrative-comment removal
- formatting

Everything that deletes code or rewrites behaviour/attributes is skipped:

- console and dead-code removal (`fixDeadPatterns`)
- lint autofixes (oxlint/ruff)
- unused-declaration removal
- unused-dependency pruning (knip)
- all `-f` force steps (deps, unused files, framework alignment)

The default `fix` is unchanged. `--safe` also neutralises `-f` if both are passed.

## Behaviour

```
$ aislop fix --safe
```

On a file with an unused import and a `console.log` inside a function: the unused import is removed, the `console.log` is left untouched. The default `fix` removes both.

## How

- `PipelineDeps` gains a `safe` flag. In safe mode `runAiSlopSteps` runs a narrative-comment-only step instead of the combined "Dead code & comments" step, and the orchestrator skips the declaration, lint, dependency, and force steps.
- New `--safe` CLI flag on `fix`.

## Tests

- `tests/fix-safe-mode.test.ts` — asserts the step set: safe mode runs `Unused imports`, `Duplicate imports`, `Narrative comments` and not `Dead code & comments`; default mode runs the combined step.
- Verified end-to-end on a sample project (unused import removed, `console.log` kept under `--safe`). Full suite green.
