### PR TITLE
feat(scan): withhold the score when coverage is negligible (no fake grade)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 - **`.aislopignore`.** A root-level ignore file (same glob semantics as the `exclude` config, with `#` comments) to keep whole paths out of every scan.
 - **`aislop fix --safe`.** An opt-in mode that restricts the run to fixes that cannot change behaviour — unused-import removal, import merging, narrative-comment removal, and formatting. Anything that deletes code or rewrites behaviour/attributes (console and dead-code removal, lint autofixes, unused-declaration and dependency pruning, and all `-f` force steps) is skipped, so a `--safe` run is genuinely safe to apply and commit. The default `fix` is unchanged.
 
+### Changed
+
+- **Coverage gate — no score off a sliver.** aislop now withholds the numeric score when it could only analyse a negligible fraction of a repo: when there are no files in a supported language, or when unsupported-language code (C, C++, C#, Swift, Kotlin, and similar) outnumbers supported files by more than three to one. Previously a repo like postgres (≈1.4M lines of C) could score 91 off two incidental Python helper scripts. The scan now prints a plain explanation instead of a number, `--json` returns `score: null` with `scoreable: false` and a `coverage` breakdown, and `ci` does not gate on a withheld score.
+
 ### Fixed
 
 - **No-downgrade guard on dependency fixes.** `aislop fix -f` no longer writes a dependency override that pins a package below the version already installed. Before applying npm/pnpm overrides it reads the installed version and drops any that would be a downgrade, reporting them as "skipped downgrade(s), verify intent" instead of silently regressing a dependency the way `npm audit fix --force` does.

--- a/README.md
+++ b/README.md
@@ -90,6 +90,8 @@ exclude:
 
 Or via CLI: `npx aislop scan --exclude "**/*.test.ts,dist"`
 
+**Unsupported languages**: aislop only analyses the 8 languages above. If a repo is mostly something else (C, C++, C#, Swift, Kotlin, …), scoring a handful of incidental files would misrepresent it, so aislop **withholds the score** and says so rather than printing a number off code it never read. `--json` returns `score: null`, `scoreable: false`, and a `coverage` breakdown.
+
 **Per-rule severity**: Override the severity of any rule by id, or turn it off:
 
 ```yaml

--- a/src/commands/scan-coverage.ts
+++ b/src/commands/scan-coverage.ts
@@ -1,0 +1,41 @@
+import { renderHeader } from "../ui/header.js";
+import { createSymbols } from "../ui/symbols.js";
+import { createTheme } from "../ui/theme.js";
+import type { Coverage, ProjectInfo } from "../utils/discover.js";
+import { APP_VERSION } from "../version.js";
+
+export const coverageReason = (c: Coverage): string => {
+	if (c.supportedFiles === 0 && c.dominantUnsupported) {
+		return `This repository is ${c.dominantUnsupported} (${c.unsupportedFiles} files), which aislop does not analyze. No score — it would not reflect this code.`;
+	}
+	if (c.supportedFiles === 0) {
+		return "No files in a language aislop analyzes (TypeScript, JavaScript, Python, Go, Rust, Ruby, PHP, Java). Nothing to score.";
+	}
+	const lang = c.dominantUnsupported ?? "an unsupported language";
+	const files = `${c.supportedFiles} supported file${c.supportedFiles === 1 ? "" : "s"}`;
+	return `This repository is mostly ${lang} (${c.unsupportedFiles} files); aislop analyzed only ${files}. Score withheld — it would represent a sliver of the codebase.`;
+};
+
+export const renderCoverageNotice = (projectInfo: ProjectInfo, includeHeader: boolean): string => {
+	const deps = {
+		theme: createTheme(),
+		symbols: createSymbols({ plain: false }),
+	};
+	const header =
+		includeHeader === false
+			? ""
+			: renderHeader(
+					{
+						version: APP_VERSION,
+						command: "scan",
+						context: [
+							projectInfo.projectName,
+							projectInfo.languages[0] ?? "unknown",
+							`${projectInfo.sourceFileCount} files`,
+						],
+						brand: true,
+					},
+					deps,
+				);
+	return `${header}  ${coverageReason(projectInfo.coverage)}\n\n`;
+};

--- a/src/commands/scan.ts
+++ b/src/commands/scan.ts
@@ -33,6 +33,7 @@ import {
 } from "../utils/source-files.js";
 import { applySuppressions } from "../utils/suppress.js";
 import { APP_VERSION } from "../version.js";
+import { renderCoverageNotice } from "./scan-coverage.js";
 
 interface ScanOptions {
 	changes: boolean;
@@ -343,8 +344,9 @@ const runScanBody = async (
 		projectInfo.sourceFileCount,
 		config.scoring.smoothing,
 	);
+	const scoreable = projectInfo.coverage.scoreable;
 	const hasErrors = allDiagnostics.some((d) => d.severity === "error");
-	const exitCode = hasErrors || scoreResult.score < config.ci.failBelow ? 1 : 0;
+	const exitCode = scoreable && (hasErrors || scoreResult.score < config.ci.failBelow) ? 1 : 0;
 
 	const engineIssues: EngineCounts = {};
 	const engineTimings: EngineCounts = {};
@@ -354,7 +356,8 @@ const runScanBody = async (
 	}
 	const completion = {
 		exitCode,
-		score: scoreResult.score,
+		score: scoreable ? scoreResult.score : null,
+		scoreable,
 		findingCount: allDiagnostics.length,
 		errorCount: allDiagnostics.filter((d) => d.severity === "error").length,
 		warningCount: allDiagnostics.filter((d) => d.severity === "warning").length,
@@ -371,8 +374,21 @@ const runScanBody = async (
 
 	if (options.json) {
 		const { buildJsonOutput } = await import("../output/json.js");
-		const jsonOut = buildJsonOutput(results, scoreResult, projectInfo.sourceFileCount, elapsedMs);
+		const jsonOut = buildJsonOutput(
+			results,
+			scoreResult,
+			projectInfo.sourceFileCount,
+			elapsedMs,
+			projectInfo.coverage,
+		);
 		console.log(JSON.stringify(jsonOut, null, 2));
+		return completion;
+	}
+
+	if (!scoreable) {
+		if (!machineOutput) {
+			process.stdout.write(renderCoverageNotice(projectInfo, showHeader));
+		}
 		return completion;
 	}
 

--- a/src/output/json.ts
+++ b/src/output/json.ts
@@ -1,5 +1,6 @@
 import type { Diagnostic, EngineResult } from "../engines/types.js";
 import type { ScoreResult } from "../scoring/index.js";
+import type { Coverage } from "../utils/discover.js";
 import { APP_VERSION } from "../version.js";
 import { ENGINE_INFO, type EngineInfo } from "./engine-info.js";
 
@@ -7,8 +8,10 @@ interface JsonOutput {
 	schemaVersion: string;
 	cliVersion: string;
 	version: string;
-	score: number;
+	score: number | null;
 	label: string;
+	scoreable: boolean;
+	coverage: Coverage;
 	engines: Record<string, { issues: number; skipped: boolean; elapsed: number }>;
 	engineDefinitions: Record<string, EngineInfo>;
 	diagnostics: Diagnostic[];
@@ -26,6 +29,7 @@ export const buildJsonOutput = (
 	scoreResult: ScoreResult,
 	fileCount: number,
 	elapsedMs: number,
+	coverage: Coverage,
 ): JsonOutput => {
 	const allDiagnostics = results.flatMap((r) => r.diagnostics);
 	const engines: JsonOutput["engines"] = {};
@@ -42,8 +46,10 @@ export const buildJsonOutput = (
 		schemaVersion: "1",
 		cliVersion: APP_VERSION,
 		version: APP_VERSION,
-		score: scoreResult.score,
-		label: scoreResult.label,
+		score: coverage.scoreable ? scoreResult.score : null,
+		label: coverage.scoreable ? scoreResult.label : "not scored",
+		scoreable: coverage.scoreable,
+		coverage,
 		engines,
 		engineDefinitions: ENGINE_INFO,
 		diagnostics: allDiagnostics,

--- a/src/telemetry/lifecycle.ts
+++ b/src/telemetry/lifecycle.ts
@@ -1,5 +1,5 @@
 import { performance } from "node:perf_hooks";
-import { flushTelemetry, track, type TelemetryConfig } from "./client.js";
+import { flushTelemetry, type TelemetryConfig, track } from "./client.js";
 import {
 	buildCommandCompletedProps,
 	buildCommandStartedProps,
@@ -17,7 +17,8 @@ interface CommandLifecycleStart {
 
 interface CommandCompletionInfo {
 	exitCode: number;
-	score?: number;
+	score?: number | null;
+	scoreable?: boolean;
 	findingCount?: number;
 	errorCount?: number;
 	warningCount?: number;
@@ -56,7 +57,7 @@ export const withCommandLifecycle = async <T extends CommandCompletionInfo>(
 				startProps,
 				exitCode: result.exitCode,
 				durationMs,
-				score: result.score,
+				score: result.score ?? undefined,
 				findingCount: result.findingCount,
 				errorCount: result.errorCount,
 				warningCount: result.warningCount,

--- a/src/utils/discover.ts
+++ b/src/utils/discover.ts
@@ -1,6 +1,6 @@
 import fs from "node:fs";
 import path from "node:path";
-import { getSourceFilesForRoot, listProjectFiles } from "./source-files.js";
+import { filterProjectFiles, getSourceFilesForRoot, listProjectFiles } from "./source-files.js";
 import { isToolAvailable } from "./tooling.js";
 
 export type Language =
@@ -80,7 +80,14 @@ const UNSUPPORTED_CODE_EXTENSIONS: Record<string, string> = {
 const analyzeCoverage = (rootDirectory: string, supportedFiles: number): Coverage => {
 	const counts = new Map<string, number>();
 	let unsupportedFiles = 0;
-	for (const file of listProjectFiles(rootDirectory)) {
+	// Count through the same exclusion pipeline as supported files so an excluded
+	// subtree (vendor/, tests/, examples/, gitignored) can't skew the gate.
+	const candidates = filterProjectFiles(
+		rootDirectory,
+		listProjectFiles(rootDirectory),
+		Object.keys(UNSUPPORTED_CODE_EXTENSIONS),
+	);
+	for (const file of candidates) {
 		const lang = UNSUPPORTED_CODE_EXTENSIONS[path.extname(file).toLowerCase()];
 		if (!lang) continue;
 		unsupportedFiles += 1;

--- a/src/utils/discover.ts
+++ b/src/utils/discover.ts
@@ -1,6 +1,6 @@
 import fs from "node:fs";
 import path from "node:path";
-import { getSourceFilesForRoot } from "./source-files.js";
+import { getSourceFilesForRoot, listProjectFiles } from "./source-files.js";
 import { isToolAvailable } from "./tooling.js";
 
 export type Language =
@@ -25,14 +25,83 @@ export type Framework =
 	| "fastapi"
 	| "none";
 
+export interface Coverage {
+	supportedFiles: number;
+	unsupportedFiles: number;
+	dominantUnsupported: string | null;
+	scoreable: boolean;
+}
+
 export interface ProjectInfo {
 	rootDirectory: string;
 	projectName: string;
 	languages: Language[];
 	frameworks: Framework[];
 	sourceFileCount: number;
+	coverage: Coverage;
 	installedTools: Record<string, boolean>;
 }
+
+// Primary-language extensions aislop has no analyzer for. Used only to judge whether
+// a numeric score would represent the repo or just a sliver of incidental files.
+const UNSUPPORTED_CODE_EXTENSIONS: Record<string, string> = {
+	".c": "C/C++",
+	".h": "C/C++",
+	".cc": "C/C++",
+	".cpp": "C/C++",
+	".cxx": "C/C++",
+	".hpp": "C/C++",
+	".hh": "C/C++",
+	".hxx": "C/C++",
+	".cs": "C#",
+	".swift": "Swift",
+	".kt": "Kotlin",
+	".kts": "Kotlin",
+	".m": "Objective-C",
+	".mm": "Objective-C",
+	".scala": "Scala",
+	".dart": "Dart",
+	".ex": "Elixir",
+	".exs": "Elixir",
+	".erl": "Erlang",
+	".hs": "Haskell",
+	".clj": "Clojure",
+	".cljs": "Clojure",
+	".lua": "Lua",
+	".jl": "Julia",
+	".zig": "Zig",
+	".nim": "Nim",
+	".ml": "OCaml",
+	".fs": "F#",
+	".sol": "Solidity",
+	".groovy": "Groovy",
+};
+
+const analyzeCoverage = (rootDirectory: string, supportedFiles: number): Coverage => {
+	const counts = new Map<string, number>();
+	let unsupportedFiles = 0;
+	for (const file of listProjectFiles(rootDirectory)) {
+		const lang = UNSUPPORTED_CODE_EXTENSIONS[path.extname(file).toLowerCase()];
+		if (!lang) continue;
+		unsupportedFiles += 1;
+		counts.set(lang, (counts.get(lang) ?? 0) + 1);
+	}
+
+	let dominantUnsupported: string | null = null;
+	let max = 0;
+	for (const [lang, count] of counts) {
+		if (count > max) {
+			max = count;
+			dominantUnsupported = lang;
+		}
+	}
+
+	// Withhold the score when aislop only saw a sliver: nothing it can analyze, or
+	// unsupported-language code outnumbers supported files by more than three to one.
+	const negligible =
+		supportedFiles === 0 || (unsupportedFiles >= 10 && unsupportedFiles > supportedFiles * 3);
+	return { supportedFiles, unsupportedFiles, dominantUnsupported, scoreable: !negligible };
+};
 
 const LANGUAGE_SIGNALS: Record<string, Language> = {
 	"tsconfig.json": "typescript",
@@ -215,6 +284,7 @@ export const discoverProject = async (directory: string): Promise<ProjectInfo> =
 	const languages = detectLanguages(resolvedDir);
 	const frameworks = detectFrameworks(resolvedDir);
 	const sourceFileCount = countSourceFiles(resolvedDir);
+	const coverage = analyzeCoverage(resolvedDir, sourceFileCount);
 	const installedTools = await checkInstalledTools();
 
 	const packageJson = readPackageJson(path.join(resolvedDir, "package.json"));
@@ -226,6 +296,7 @@ export const discoverProject = async (directory: string): Promise<ProjectInfo> =
 		languages,
 		frameworks,
 		sourceFileCount,
+		coverage,
 		installedTools,
 	};
 };

--- a/tests/coverage-gate.test.ts
+++ b/tests/coverage-gate.test.ts
@@ -1,0 +1,95 @@
+import { execFileSync } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { coverageReason } from "../src/commands/scan-coverage.js";
+import { discoverProject } from "../src/utils/discover.js";
+
+let tmpDir: string;
+
+const write = (rel: string, content: string) => {
+	const p = path.join(tmpDir, rel);
+	fs.mkdirSync(path.dirname(p), { recursive: true });
+	fs.writeFileSync(p, content, "utf-8");
+};
+
+beforeEach(() => {
+	tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "aislop-coverage-"));
+	execFileSync("git", ["init"], { cwd: tmpDir, stdio: "ignore" });
+});
+
+afterEach(() => {
+	fs.rmSync(tmpDir, { recursive: true, force: true });
+});
+
+describe("coverage gate (discoverProject)", () => {
+	it("withholds the score for a repo dominated by an unsupported language", async () => {
+		for (let i = 0; i < 15; i++) write(`f${i}.c`, "int main(){return 0;}\n");
+		write("util.py", "def add(a, b):\n    return a + b\n");
+
+		const info = await discoverProject(tmpDir);
+		expect(info.coverage.scoreable).toBe(false);
+		expect(info.coverage.dominantUnsupported).toBe("C/C++");
+		expect(info.coverage.unsupportedFiles).toBe(15);
+	});
+
+	it("scores a normal supported-language repo", async () => {
+		for (let i = 0; i < 5; i++) write(`src/m${i}.ts`, `export const v${i} = ${i};\n`);
+
+		const info = await discoverProject(tmpDir);
+		expect(info.coverage.scoreable).toBe(true);
+		expect(info.coverage.unsupportedFiles).toBe(0);
+	});
+
+	it("still scores a supported repo with a minority of unsupported files", async () => {
+		for (let i = 0; i < 30; i++) write(`m${i}.py`, `def f${i}():\n    return ${i}\n`);
+		for (let i = 0; i < 5; i++) write(`ext${i}.c`, "int x;\n");
+
+		const info = await discoverProject(tmpDir);
+		expect(info.coverage.scoreable).toBe(true);
+	});
+
+	it("withholds when there are no supported files to analyze", async () => {
+		write("README.md", "# docs only\n");
+		write("notes.md", "nothing to score\n");
+
+		const info = await discoverProject(tmpDir);
+		expect(info.coverage.supportedFiles).toBe(0);
+		expect(info.coverage.scoreable).toBe(false);
+	});
+});
+
+describe("coverageReason", () => {
+	it("names the dominant language when nothing supported was found", () => {
+		const msg = coverageReason({
+			supportedFiles: 0,
+			unsupportedFiles: 6000,
+			dominantUnsupported: "C/C++",
+			scoreable: false,
+		});
+		expect(msg).toContain("C/C++");
+		expect(msg).toContain("does not analyze");
+	});
+
+	it("explains the sliver case when a few supported files exist", () => {
+		const msg = coverageReason({
+			supportedFiles: 2,
+			unsupportedFiles: 6000,
+			dominantUnsupported: "C/C++",
+			scoreable: false,
+		});
+		expect(msg).toContain("only 2 supported files");
+		expect(msg).toContain("Score withheld");
+	});
+
+	it("falls back to a generic message with no code at all", () => {
+		const msg = coverageReason({
+			supportedFiles: 0,
+			unsupportedFiles: 0,
+			dominantUnsupported: null,
+			scoreable: false,
+		});
+		expect(msg).toContain("Nothing to score");
+	});
+});

--- a/tests/coverage-gate.test.ts
+++ b/tests/coverage-gate.test.ts
@@ -50,6 +50,15 @@ describe("coverage gate (discoverProject)", () => {
 		expect(info.coverage.scoreable).toBe(true);
 	});
 
+	it("does not count an excluded subtree (vendor/) toward unsupported coverage", async () => {
+		for (let i = 0; i < 5; i++) write(`src/m${i}.ts`, `export const v${i} = ${i};\n`);
+		for (let i = 0; i < 50; i++) write(`vendor/lib/c${i}.c`, "int x;\n");
+
+		const info = await discoverProject(tmpDir);
+		expect(info.coverage.unsupportedFiles).toBe(0);
+		expect(info.coverage.scoreable).toBe(true);
+	});
+
 	it("withholds when there are no supported files to analyze", async () => {
 		write("README.md", "# docs only\n");
 		write("notes.md", "nothing to score\n");

--- a/tests/output/json.test.ts
+++ b/tests/output/json.test.ts
@@ -1,11 +1,19 @@
 import { describe, expect, it } from "vitest";
-import { buildJsonOutput } from "../../src/output/json.js";
 import type { EngineResult } from "../../src/engines/types.js";
+import { buildJsonOutput } from "../../src/output/json.js";
+import type { Coverage } from "../../src/utils/discover.js";
+
+const scoreable: Coverage = {
+	supportedFiles: 10,
+	unsupportedFiles: 0,
+	dominantUnsupported: null,
+	scoreable: true,
+};
 
 describe("json output", () => {
 	it("includes schemaVersion and cliVersion", () => {
 		const results: EngineResult[] = [];
-		const out = buildJsonOutput(results, { score: 100, label: "Excellent" }, 0, 10);
+		const out = buildJsonOutput(results, { score: 100, label: "Excellent" }, 0, 10, scoreable);
 		expect(out.schemaVersion).toBe("1");
 		expect(typeof out.cliVersion).toBe("string");
 		expect(out.cliVersion.length).toBeGreaterThan(0);
@@ -13,8 +21,20 @@ describe("json output", () => {
 
 	it("preserves existing top-level fields", () => {
 		const results: EngineResult[] = [];
-		const out = buildJsonOutput(results, { score: 89, label: "Healthy" }, 1500, 50);
+		const out = buildJsonOutput(results, { score: 89, label: "Healthy" }, 1500, 50, scoreable);
 		expect(out.score).toBe(89);
 		expect(out.label).toBe("Healthy");
+	});
+
+	it("withholds the score when coverage is not scoreable", () => {
+		const out = buildJsonOutput([], { score: 91, label: "Healthy" }, 10, 10, {
+			supportedFiles: 2,
+			unsupportedFiles: 6000,
+			dominantUnsupported: "C/C++",
+			scoreable: false,
+		});
+		expect(out.score).toBeNull();
+		expect(out.scoreable).toBe(false);
+		expect(out.coverage.dominantUnsupported).toBe("C/C++");
 	});
 });


### PR DESCRIPTION
## Why

aislop analyses 8 languages (TS/JS/Python/Go/Rust/Ruby/PHP/Java), but it still emitted a confident numeric score even when it had looked at almost none of a repo. Concretely:

- **postgres/postgres** (~1.4M lines of **C**) scored **91** — off exactly two incidental Python helper scripts in `contrib/`, scanned in ~1s. The C core was never analysed.
- A docs-only or skills repo scored **100** off no real code.

A confident score off a sliver of a repo is misleading. The score has to mean "we looked at this code," and for these repos we didn't.

## What

Discovery now classifies every tracked file and counts **unsupported-language code** (C/C++, C#, Swift, Kotlin, Objective-C, Scala, Dart, Elixir, Haskell, Clojure, Lua, Julia, Zig, Nim, OCaml, F#, Solidity, Groovy) alongside supported source files. A repo is marked **unscoreable** when:

- there are **no** files in a supported language, or
- unsupported-language code **outnumbers supported files by more than 3:1**.

When unscoreable, aislop **withholds the score**:

- **Terminal:** a plain explanation instead of a number — e.g. *"This repository is mostly C/C++ (6,182 files); aislop analyzed only 2 supported files. Score withheld — it would represent a sliver of the codebase."*
- **`--json`:** `score: null`, `scoreable: false`, plus a `coverage` object (`supportedFiles`, `unsupportedFiles`, `dominantUnsupported`).
- **`ci`:** does not gate on a withheld score (exit 0).
- History is not recorded for unscoreable runs.

Normal repos, and supported repos with a minority of unsupported files (e.g. a Python package with a few Cython `.c` files), are unaffected.

## Tests

- `tests/coverage-gate.test.ts` — C-dominant repo → withheld (dominant `C/C++`); normal TS repo → scored; Python + minority C → scored; docs-only → withheld; plus the three `coverageReason` message branches.
- `tests/output/json.test.ts` — withheld case returns `score: null` / `scoreable: false` / coverage.
- Full suite green (1020).