### PR TITLE
[codex] clarify aislop Action CI docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -243,7 +243,7 @@ Or wire it into the [pre-commit](https://pre-commit.com) framework via the bundl
 # .pre-commit-config.yaml
 repos:
   - repo: https://github.com/scanaislop/aislop
-    rev: v0.9.4
+    rev: v0.10.1
     hooks:
       - id: aislop
 ```
@@ -253,18 +253,42 @@ repos:
 Run `npx aislop init` and accept the workflow prompt, or add manually:
 
 ```yaml
+name: aislop
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+jobs:
+  quality-gate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: scanaislop/aislop@v0.10.1
+        with:
+          version: latest
+```
+
+`uses: scanaislop/aislop@v0.10.1` pins the GitHub Action wrapper. `version: latest` follows the latest npm CLI. For fully deterministic CI, set both to the same release:
+
+```yaml
+- uses: actions/checkout@v4
+
+- uses: scanaislop/aislop@v0.10.1
+  with:
+    version: "0.10.1"
+```
+
+Manual workflow without the Marketplace Action:
+
+```yaml
 - uses: actions/checkout@v4
 - uses: actions/setup-node@v4
   with:
     node-version: 20
-- run: npx aislop@latest ci .
-```
-
-**Composite action**:
-
-```yaml
-- uses: actions/checkout@v4
-- uses: scanaislop/aislop@v0.8
+- run: npx --yes aislop@latest ci .
 ```
 
 **GitHub code scanning (SARIF)**: emit a SARIF 2.1.0 report and upload it so findings appear in the Security tab:

--- a/action.yml
+++ b/action.yml
@@ -19,7 +19,7 @@ inputs:
     required: false
     default: "json"
   version:
-    description: aislop version to run (e.g. "0.5.0"). Defaults to the latest published.
+    description: npm aislop CLI version to run (e.g. "0.10.1"). Use "latest" to follow the latest published CLI. This is separate from the GitHub Action ref in uses:.
     required: false
     default: "latest"
 

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -4,7 +4,11 @@
 
 Run `npx aislop init` and answer "yes" to the GitHub Actions workflow prompt. It writes `.aislop/config.yml` and `.github/workflows/aislop.yml` for you. Commit both and your quality gate is live.
 
+`.github/workflows/aislop.yml` is the GitHub Actions workflow file. You can rename the file, but it must live under `.github/workflows/`. `.aislop/config.yml` is the aislop policy file: thresholds, engines, scoring, and telemetry live there.
+
 ## GitHub Actions
+
+Recommended Marketplace Action:
 
 ```yaml
 # .github/workflows/aislop.yml
@@ -20,17 +24,35 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+
+      - uses: scanaislop/aislop@v0.10.1
         with:
-          node-version: 20
-      - run: npx aislop@latest ci .
+          version: latest
 ```
 
-Or the composite action (one-liner):
+For deterministic CI, pin both layers:
 
 ```yaml
 - uses: actions/checkout@v4
-- uses: scanaislop/aislop@v0.5
+
+- uses: scanaislop/aislop@v0.10.1
+  with:
+    version: "0.10.1"
+```
+
+Versioning has two separate knobs:
+
+- `uses: scanaislop/aislop@v0.10.1` is the GitHub Action wrapper ref. It must be a real Git tag, branch, or SHA. GitHub does not resolve `@latest` unless this repository creates and maintains such a ref.
+- `version: latest` is the npm CLI version the Action runs. It maps to the npm `latest` dist-tag.
+
+Manual workflow without the Marketplace Action:
+
+```yaml
+- uses: actions/checkout@v4
+- uses: actions/setup-node@v4
+  with:
+    node-version: 20
+- run: npx --yes aislop@latest ci .
 ```
 
 `aislop ci` outputs JSON and exits with code 1 if the score is below the configured threshold or any error-severity diagnostic is present.
@@ -42,7 +64,7 @@ Or the composite action (one-liner):
 aislop:
   image: node:20
   script:
-    - npx aislop@latest ci .
+    - npx --yes aislop@latest ci .
   rules:
     - if: $CI_PIPELINE_SOURCE == "merge_request_event"
     - if: $CI_COMMIT_BRANCH == "main"
@@ -59,7 +81,7 @@ jobs:
       - image: cimg/node:20.0
     steps:
       - checkout
-      - run: npx aislop@latest ci .
+      - run: npx --yes aislop@latest ci .
 workflows:
   quality-gate:
     jobs:
@@ -101,7 +123,7 @@ Both `aislop ci` and `aislop scan --json` produce structured JSON output suitabl
 ```json
 {
   "schemaVersion": "1",
-  "cliVersion": "0.5.0",
+  "cliVersion": "0.10.1",
   "score": 87,
   "label": "Healthy",
   "engines": {


### PR DESCRIPTION
## Summary

Clarifies the GitHub Actions setup now that the Marketplace Action is the preferred path:

- documents `uses: scanaislop/aislop@v0.10.1` as the Action wrapper ref
- explains that `version: latest` follows the npm CLI dist-tag and is separate from the GitHub Action ref
- adds deterministic pinning examples and keeps the manual `npx --yes aislop@latest ci .` fallback
- updates stale README, CI docs, and Action input examples

## Validation

- `gh release view --repo scanaislop/aislop --json tagName,publishedAt,name` -> `v0.10.1`, published 2026-05-30
- `npm view aislop version --silent` -> `0.10.1`
- `npm view aislop dist-tags --json --silent` -> `latest: 0.10.1`
- `git ls-remote --heads origin 'v*' 'latest'` -> no floating Action branch found
- `pnpm test` -> 95 files / 1023 tests passed
- `aislop scan --changes --json` -> score 100, 0 diagnostics