### PR TITLE
chore: release v0.10.2

### DIFF
--- a/.github/workflows/aislop.yml
+++ b/.github/workflows/aislop.yml
@@ -73,6 +73,7 @@ jobs:
         uses: ./
         with:
           directory: ${{ runner.temp }}/aislop-action-fixture
+          # Keep this on the latest already-published npm version; release PRs run before the new npm package exists.
           version: "0.10.1"
 
   quality-gate:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,9 +1,8 @@
 name: Release
 
 on:
-  push:
-    tags:
-      - "v*"
+  release:
+    types: [published]
 
 permissions:
   contents: write
@@ -17,6 +16,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event.release.tag_name }}
 
       - uses: pnpm/action-setup@v4
 
@@ -46,11 +47,6 @@ jobs:
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
-      - name: Create GitHub Release
-        uses: softprops/action-gh-release@v2
-        with:
-          generate_release_notes: true
-
   publish-gpr:
     name: Publish to GitHub Packages
     runs-on: ubuntu-latest
@@ -58,6 +54,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event.release.tag_name }}
 
       - uses: pnpm/action-setup@v4
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,11 +6,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## Unreleased
 
+## 0.10.2 (2026-06-02)
+
+A patch release focused on safer release/CI plumbing and sharper scan consistency. The GitHub Action now keeps wrapper and npm CLI versions separate without letting exact npm pins be shadowed by a checked-out local package, `aislop init` emits reproducible pinned workflows, and the rule catalog/docs now stay aligned with the implemented detectors.
+
 ### Added
 
 - **Suppression.** Silence a finding you have judged intentional with an inline directive: `// aislop-ignore-next-line [rule...]` (line below), `// aislop-ignore-line [rule...]` (same line), or `// aislop-ignore-file [rule...]` (whole file). Name one or more rules to scope it, or omit them to silence every rule on that line, and add a reason after `--`. Works in any comment syntax (`//`, `#`, `<!-- -->`). Directive lines are invisible to the comment engines, so they never join a comment block or get flagged themselves. Suppressed findings are dropped before scoring, and the run reports how many were silenced.
 - **`.aislopignore`.** A root-level ignore file (same glob semantics as the `exclude` config, with `#` comments) to keep whole paths out of every scan.
 - **`aislop fix --safe`.** An opt-in mode that restricts the run to fixes that cannot change behaviour — unused-import removal, import merging, narrative-comment removal, and formatting. Anything that deletes code or rewrites behaviour/attributes (console and dead-code removal, lint autofixes, unused-declaration and dependency pruning, and all `-f` force steps) is skipped, so a `--safe` run is genuinely safe to apply and commit. The default `fix` is unchanged.
+- **Action smoke coverage.** The repository CI now exercises the composite GitHub Action in default `latest`, explicit `latest`, pinned npm-version, JSON, human, and node-version override modes.
 
 ### Changed
 
@@ -22,6 +27,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 - **CVE root-cause collapse.** The dependency audit now attributes a transitive vulnerability to the package that actually carries the advisory rather than emitting a near-duplicate finding for every intermediate package in the chain, so one root CVE reads as one issue instead of ten.
 - **Python comma imports.** The unused-import fixer treated `import os, sys` as a single binding, so one unused module (`os`) deleted the whole line and broke the used one (`sys`). Each comma-separated module is now considered independently: the unused one is trimmed (`import os, sys` → `import sys`), the line is removed only when every module is unused, and a line where all are used is left alone.
 - **Hook telemetry never sent.** The per-edit hook (`aislop hook <agent>`) emits its `hook_scan_completed` event with a fire-and-forget request, but the short-lived process called `process.exit()` before the request left the machine, so the event was always dropped (hook-install/status/etc. were unaffected since they flush via the command lifecycle). The hook now flushes telemetry before exiting, bounded to 1.5s so it never stalls the agent's edit.
+- **GitHub Action exact-version pins.** Exact npm pins such as `version: "0.10.1"` now run from an isolated temp directory so npm cannot resolve the checked-out local package metadata instead of the published package.
+- **Rule catalog consistency.** `aislop rules`, rule labels, and `docs/rules.md` now cover the implemented camel-case and newly-added rule IDs consistently, including `knip/devDependencies`, duplicate exports, dependency-audit skips, and React `dangerouslySetInnerHTML`.
+- **Empty function detection.** `ai-slop/empty-function` now recognises normal JavaScript/TypeScript function declarations with parameter lists instead of only arrow stubs or malformed function headers.
+
+### Tests
+
+Full suite at 1029 passing, plus self-scan at 100 with zero diagnostics. New coverage locks the action manifest/workflow behavior, empty-function detection, shell-injection interpolation, and rule catalog label/doc parity.
 
 ## 0.10.1 (2026-05-30)
 

--- a/README.md
+++ b/README.md
@@ -243,7 +243,7 @@ Or wire it into the [pre-commit](https://pre-commit.com) framework via the bundl
 # .pre-commit-config.yaml
 repos:
   - repo: https://github.com/scanaislop/aislop
-    rev: v0.10.1
+    rev: v0.10.2
     hooks:
       - id: aislop
 ```
@@ -266,19 +266,19 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: scanaislop/aislop@v0.10.1
+      - uses: scanaislop/aislop@v0.10.2
         with:
           version: latest
 ```
 
-`uses: scanaislop/aislop@v0.10.1` pins the GitHub Action wrapper. `version: latest` follows the latest npm CLI. For fully deterministic CI, set both to the same release:
+`uses: scanaislop/aislop@v0.10.2` pins the GitHub Action wrapper. `version: latest` follows the latest npm CLI. For fully deterministic CI, set both to the same release:
 
 ```yaml
 - uses: actions/checkout@v4
 
-- uses: scanaislop/aislop@v0.10.1
+- uses: scanaislop/aislop@v0.10.2
   with:
-    version: "0.10.1"
+    version: "0.10.2"
 ```
 
 Manual workflow without the Marketplace Action:

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -25,7 +25,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: scanaislop/aislop@v0.10.1
+      - uses: scanaislop/aislop@v0.10.2
         with:
           version: latest
 ```
@@ -35,14 +35,14 @@ For deterministic CI, pin both layers:
 ```yaml
 - uses: actions/checkout@v4
 
-- uses: scanaislop/aislop@v0.10.1
+- uses: scanaislop/aislop@v0.10.2
   with:
-    version: "0.10.1"
+    version: "0.10.2"
 ```
 
 Versioning has two separate knobs:
 
-- `uses: scanaislop/aislop@v0.10.1` is the GitHub Action wrapper ref. It must be a real Git tag, branch, or SHA. GitHub does not resolve `@latest` unless this repository creates and maintains such a ref.
+- `uses: scanaislop/aislop@v0.10.2` is the GitHub Action wrapper ref. It must be a real Git tag, branch, or SHA. GitHub does not resolve `@latest` unless this repository creates and maintains such a ref.
 - `version: latest` is the npm CLI version the Action runs. It maps to the npm `latest` dist-tag.
 
 Manual workflow without the Marketplace Action:
@@ -123,7 +123,7 @@ Both `aislop ci` and `aislop scan --json` produce structured JSON output suitabl
 ```json
 {
   "schemaVersion": "1",
-  "cliVersion": "0.10.1",
+  "cliVersion": "0.10.2",
   "score": 87,
   "label": "Healthy",
   "engines": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aislop",
-  "version": "0.10.1",
+  "version": "0.10.2",
   "description": "Catch the slop AI coding agents leave in your code: narrative comments, swallowed exceptions, as-any casts, dead code, oversized functions. 50+ rules across 7 languages (TypeScript, JavaScript, Python, Go, Rust, Ruby, PHP). Sub-second, deterministic, no LLM at runtime. MIT-licensed.",
   "type": "module",
   "bin": {

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,1 +1,1 @@
-export const APP_VERSION = process.env.VERSION ?? "0.10.1";
+export const APP_VERSION = process.env.VERSION ?? "0.10.2";

--- a/tests/commands/init.workflow.test.ts
+++ b/tests/commands/init.workflow.test.ts
@@ -23,8 +23,8 @@ describe("writeGithubWorkflow", () => {
 		}
 		const body = fs.readFileSync(path.join(tmpDir, ".github/workflows/aislop.yml"), "utf-8");
 		expect(body).toContain("name: aislop");
-		expect(body).toContain("uses: scanaislop/aislop@v0.10.1");
-		expect(body).toContain("version: 0.10.1");
+		expect(body).toContain("uses: scanaislop/aislop@v0.10.2");
+		expect(body).toContain("version: 0.10.2");
 	});
 
 	it("returns declined (no write) when disabled", () => {


### PR DESCRIPTION
## Summary
- bump the CLI package and runtime fallback to 0.10.2
- promote the 0.10.2 changelog entry and update README/CI/init workflow examples
- switch publishing to the GitHub release published event so draft releases/tags do not publish packages

## Validation
- pnpm quality
- npm pack --dry-run

## Notes
- action smoke keeps the pinned npm case on 0.10.1 because release PR checks run before 0.10.2 exists on npm