### PR TITLE
fix(scan): CI fails on errors when unscoreable; coverage gate honors excludes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ A patch release focused on safer release/CI plumbing and sharper scan consistenc
 
 ### Changed
 
-- **Coverage gate — no score off a sliver.** aislop now withholds the numeric score when it could only analyse a negligible fraction of a repo: when there are no files in a supported language, or when unsupported-language code (C, C++, C#, Swift, Kotlin, and similar) outnumbers supported files by more than three to one. Previously a repo like postgres (≈1.4M lines of C) could score 91 off two incidental Python helper scripts. The scan now prints a plain explanation instead of a number, `--json` returns `score: null` with `scoreable: false` and a `coverage` breakdown, and `ci` does not gate on a withheld score.
+- **Coverage gate — no score off a sliver.** aislop now withholds the numeric score when it could only analyse a negligible fraction of a repo: when there are no files in a supported language, or when unsupported-language code (C, C++, C#, Swift, Kotlin, and similar) outnumbers supported files by more than three to one. Previously a repo like postgres (≈1.4M lines of C) could score 91 off two incidental Python helper scripts. The scan now prints a plain explanation instead of a number, `--json` returns `score: null` with `scoreable: false` and a `coverage` breakdown, and `ci` does not gate on a withheld score (but still fails on any error-severity diagnostic). The gate counts files through the same exclude patterns as the scan (`exclude` config and `.aislopignore`), so an intentionally ignored subtree never withholds the score for the code that was scanned.
 
 ### Fixed
 

--- a/src/commands/scan-exit-code.ts
+++ b/src/commands/scan-exit-code.ts
@@ -1,0 +1,7 @@
+// Error diagnostics always fail CI; the score threshold only applies when the score is scoreable (a withheld score can't be compared to failBelow).
+export const computeScanExitCode = (opts: {
+	hasErrors: boolean;
+	scoreable: boolean;
+	score: number;
+	failBelow: number;
+}): number => (opts.hasErrors || (opts.scoreable && opts.score < opts.failBelow) ? 1 : 0);

--- a/src/commands/scan.ts
+++ b/src/commands/scan.ts
@@ -34,6 +34,7 @@ import {
 import { applySuppressions } from "../utils/suppress.js";
 import { APP_VERSION } from "../version.js";
 import { renderCoverageNotice } from "./scan-coverage.js";
+import { computeScanExitCode } from "./scan-exit-code.js";
 
 interface ScanOptions {
 	changes: boolean;
@@ -218,7 +219,8 @@ export const scanCommand = async (
 		return { exitCode: 1 };
 	}
 
-	const projectInfo = await discoverProject(resolvedDir);
+	const excludePatterns = [...config.exclude, ...readAislopIgnorePatterns(resolvedDir)];
+	const projectInfo = await discoverProject(resolvedDir, excludePatterns);
 
 	return withCommandLifecycle(
 		{
@@ -346,7 +348,12 @@ const runScanBody = async (
 	);
 	const scoreable = projectInfo.coverage.scoreable;
 	const hasErrors = allDiagnostics.some((d) => d.severity === "error");
-	const exitCode = scoreable && (hasErrors || scoreResult.score < config.ci.failBelow) ? 1 : 0;
+	const exitCode = computeScanExitCode({
+		hasErrors,
+		scoreable,
+		score: scoreResult.score,
+		failBelow: config.ci.failBelow,
+	});
 
 	const engineIssues: EngineCounts = {};
 	const engineTimings: EngineCounts = {};

--- a/src/utils/discover.ts
+++ b/src/utils/discover.ts
@@ -77,17 +77,15 @@ const UNSUPPORTED_CODE_EXTENSIONS: Record<string, string> = {
 	".groovy": "Groovy",
 };
 
-const analyzeCoverage = (
-	rootDirectory: string,
-	supportedFiles: number,
-	excludePatterns: string[] = [],
-): Coverage => {
+const analyzeCoverage = (rootDirectory: string, excludePatterns: string[] = []): Coverage => {
+	// Count both sides through the scan's own post-exclude file selection, so the gate reflects exactly what was analyzed.
+	const allFiles = listProjectFiles(rootDirectory);
+	const supportedFiles = filterProjectFiles(rootDirectory, allFiles, [], excludePatterns).length;
 	const counts = new Map<string, number>();
 	let unsupportedFiles = 0;
-	// Apply the scan's exclude patterns too, so a subtree the scan skips can't skew the gate.
 	const candidates = filterProjectFiles(
 		rootDirectory,
-		listProjectFiles(rootDirectory),
+		allFiles,
 		Object.keys(UNSUPPORTED_CODE_EXTENSIONS),
 		excludePatterns,
 	);
@@ -298,7 +296,7 @@ export const discoverProject = async (
 	const languages = detectLanguages(resolvedDir);
 	const frameworks = detectFrameworks(resolvedDir);
 	const sourceFileCount = countSourceFiles(resolvedDir);
-	const coverage = analyzeCoverage(resolvedDir, sourceFileCount, excludePatterns);
+	const coverage = analyzeCoverage(resolvedDir, excludePatterns);
 	const installedTools = await checkInstalledTools();
 
 	const packageJson = readPackageJson(path.join(resolvedDir, "package.json"));

--- a/src/utils/discover.ts
+++ b/src/utils/discover.ts
@@ -77,15 +77,19 @@ const UNSUPPORTED_CODE_EXTENSIONS: Record<string, string> = {
 	".groovy": "Groovy",
 };
 
-const analyzeCoverage = (rootDirectory: string, supportedFiles: number): Coverage => {
+const analyzeCoverage = (
+	rootDirectory: string,
+	supportedFiles: number,
+	excludePatterns: string[] = [],
+): Coverage => {
 	const counts = new Map<string, number>();
 	let unsupportedFiles = 0;
-	// Count through the same exclusion pipeline as supported files so an excluded
-	// subtree (vendor/, tests/, examples/, gitignored) can't skew the gate.
+	// Apply the scan's exclude patterns too, so a subtree the scan skips can't skew the gate.
 	const candidates = filterProjectFiles(
 		rootDirectory,
 		listProjectFiles(rootDirectory),
 		Object.keys(UNSUPPORTED_CODE_EXTENSIONS),
+		excludePatterns,
 	);
 	for (const file of candidates) {
 		const lang = UNSUPPORTED_CODE_EXTENSIONS[path.extname(file).toLowerCase()];
@@ -286,12 +290,15 @@ const checkInstalledTools = async (): Promise<Record<string, boolean>> => {
 	return results;
 };
 
-export const discoverProject = async (directory: string): Promise<ProjectInfo> => {
+export const discoverProject = async (
+	directory: string,
+	excludePatterns: string[] = [],
+): Promise<ProjectInfo> => {
 	const resolvedDir = path.resolve(directory);
 	const languages = detectLanguages(resolvedDir);
 	const frameworks = detectFrameworks(resolvedDir);
 	const sourceFileCount = countSourceFiles(resolvedDir);
-	const coverage = analyzeCoverage(resolvedDir, sourceFileCount);
+	const coverage = analyzeCoverage(resolvedDir, sourceFileCount, excludePatterns);
 	const installedTools = await checkInstalledTools();
 
 	const packageJson = readPackageJson(path.join(resolvedDir, "package.json"));

--- a/tests/coverage-gate.test.ts
+++ b/tests/coverage-gate.test.ts
@@ -73,6 +73,17 @@ describe("coverage gate (discoverProject)", () => {
 		expect(withExclude.coverage.scoreable).toBe(true);
 	});
 
+	it("counts supported files post-exclude, so excluding supported code can still withhold the score", async () => {
+		write("src/main.ts", "export const x = 1;\n");
+		for (let i = 0; i < 50; i++) write(`c${i}.c`, "int x;\n");
+		for (let i = 0; i < 30; i++) write(`legacy/old${i}.ts`, `export const y${i} = ${i};\n`);
+
+		// Excluding the legacy TS tree leaves 1 scanned TS file against 50 C files → withheld.
+		const info = await discoverProject(tmpDir, ["legacy"]);
+		expect(info.coverage.supportedFiles).toBe(1);
+		expect(info.coverage.scoreable).toBe(false);
+	});
+
 	it("withholds when there are no supported files to analyze", async () => {
 		write("README.md", "# docs only\n");
 		write("notes.md", "nothing to score\n");

--- a/tests/coverage-gate.test.ts
+++ b/tests/coverage-gate.test.ts
@@ -59,6 +59,20 @@ describe("coverage gate (discoverProject)", () => {
 		expect(info.coverage.scoreable).toBe(true);
 	});
 
+	it("honors user exclude patterns so an ignored unsupported tree does not withhold the score", async () => {
+		for (let i = 0; i < 5; i++) write(`src/m${i}.ts`, `export const v${i} = ${i};\n`);
+		for (let i = 0; i < 50; i++) write(`legacy/c${i}.c`, "int x;\n");
+
+		// Without the exclude the C tree dominates and the score is withheld.
+		const withoutExclude = await discoverProject(tmpDir);
+		expect(withoutExclude.coverage.scoreable).toBe(false);
+
+		// With the same exclude the scan applies, the C tree is ignored and the TS is scored.
+		const withExclude = await discoverProject(tmpDir, ["legacy"]);
+		expect(withExclude.coverage.unsupportedFiles).toBe(0);
+		expect(withExclude.coverage.scoreable).toBe(true);
+	});
+
 	it("withholds when there are no supported files to analyze", async () => {
 		write("README.md", "# docs only\n");
 		write("notes.md", "nothing to score\n");

--- a/tests/scan-exit-code.test.ts
+++ b/tests/scan-exit-code.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from "vitest";
+import { computeScanExitCode } from "../src/commands/scan-exit-code.js";
+
+describe("computeScanExitCode", () => {
+	it("fails on error diagnostics even when the score is withheld", () => {
+		expect(computeScanExitCode({ hasErrors: true, scoreable: false, score: 0, failBelow: 70 })).toBe(1);
+	});
+
+	it("fails on error diagnostics when scoreable", () => {
+		expect(computeScanExitCode({ hasErrors: true, scoreable: true, score: 100, failBelow: 70 })).toBe(1);
+	});
+
+	it("does not gate on a withheld score below the threshold", () => {
+		expect(computeScanExitCode({ hasErrors: false, scoreable: false, score: 0, failBelow: 70 })).toBe(0);
+	});
+
+	it("fails a scoreable run below the threshold", () => {
+		expect(computeScanExitCode({ hasErrors: false, scoreable: true, score: 50, failBelow: 70 })).toBe(1);
+	});
+
+	it("passes a scoreable run at or above the threshold", () => {
+		expect(computeScanExitCode({ hasErrors: false, scoreable: true, score: 80, failBelow: 70 })).toBe(0);
+	});
+});


### PR DESCRIPTION
Addresses two issues found in review of the 0.10.2 coverage gate (#176).

## P1 — CI no longer ignores error diagnostics on unscoreable repos
The exit code was `scoreable && (hasErrors || score < failBelow)`, so a repo whose score is withheld (mostly C/C++ with a few supported files) exited `0` even when a supported file had an **error**-severity finding — contradicting the documented "any error fails the run" behavior. Now: errors always fail; only the score threshold is gated on `scoreable`. Extracted to `computeScanExitCode` and unit-tested.

## P2 — Coverage gate now honors the scan's excludes
Coverage counted unsupported files without the user's `exclude` config / `.aislopignore`, so a repo that intentionally ignores a large unsupported tree could still have its score withheld for the supported code that *was* scanned. `analyzeCoverage` now applies the same exclude patterns as the scan (threaded through `discoverProject`).

## Tests
- `scan-exit-code.test.ts` — errors fail even when unscoreable; withheld score doesn't gate; scoreable threshold still applies.
- `coverage-gate.test.ts` — a user-excluded unsupported subtree flips `scoreable` from false to true.
- Full suite: 1035 passing; typecheck clean; self-scan 100/100, 0 diagnostics.

Merges into `develop` so the 0.10.2 promotion (#176) ships the corrected behavior.
