### PR TITLE
fix(scan): show findings when the score is withheld

### DIFF
--- a/src/commands/scan.ts
+++ b/src/commands/scan.ts
@@ -395,6 +395,10 @@ const runScanBody = async (
 	if (!scoreable) {
 		if (!machineOutput) {
 			process.stdout.write(renderCoverageNotice(projectInfo, showHeader));
+			// Score is withheld, but findings still ran on the supported files; show them so a CI failure on an error diagnostic is explained.
+			if (allDiagnostics.length > 0) {
+				process.stdout.write(renderDiagnostics(allDiagnostics, options.verbose ?? false));
+			}
 		}
 		return completion;
 	}

--- a/tests/scan-unscoreable-render.test.ts
+++ b/tests/scan-unscoreable-render.test.ts
@@ -1,0 +1,34 @@
+import { execFileSync } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+const CLI = fileURLToPath(new URL("../dist/cli.js", import.meta.url));
+let tmpDir: string;
+
+beforeEach(() => {
+	tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "aislop-unscoreable-"));
+	execFileSync("git", ["init"], { cwd: tmpDir, stdio: "ignore" });
+});
+
+afterEach(() => {
+	fs.rmSync(tmpDir, { recursive: true, force: true });
+});
+
+describe("unscoreable scan output", () => {
+	it("renders findings alongside the coverage notice when the score is withheld", () => {
+		for (let i = 0; i < 15; i++) {
+			fs.writeFileSync(path.join(tmpDir, `f${i}.c`), "int main(){return 0;}\n");
+		}
+		fs.writeFileSync(
+			path.join(tmpDir, "app.ts"),
+			'import { readFileSync } from "node:fs";\nexport const x = 1;\n',
+		);
+
+		const out = execFileSync("node", [CLI, "scan", "."], { cwd: tmpDir, encoding: "utf-8" });
+		expect(out).toContain("Score withheld");
+		expect(out).toContain("never used");
+	});
+});


### PR DESCRIPTION
Follow-up to the coverage gate found in review of #176.

## Problem
When the gate withholds the score, the scan printed only the coverage notice and returned. Since errors now always fail CI (regardless of `scoreable`), a mostly-unsupported repo with an error-severity finding in an analyzed file would exit `1` while showing **no diagnostic** — a failing run with nothing explaining what failed.

## Fix
In the unscoreable branch, render the findings (via `renderDiagnostics`) alongside the coverage notice, so the diagnostics that drive the exit code are always visible.

## Tests
- `scan-unscoreable-render.test.ts` — integration test: an unscoreable repo (15 C files + 1 TS file with an unused import) shows both the "Score withheld" notice and the finding.
- Full suite: 1037 passing; typecheck clean; self-scan 100/0.

Merges into `develop` so #176 ships it.
