### PR TITLE
docs: surface Homebrew + pipx install channels

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@
 
 [![npm version](https://img.shields.io/npm/v/aislop.svg)](https://www.npmjs.com/package/aislop)
 [![npm downloads](https://img.shields.io/npm/dm/aislop.svg)](https://www.npmjs.com/package/aislop)
+[![PyPI downloads](https://img.shields.io/pepy/dt/aislop.svg?label=PyPI%20downloads)](https://pypi.org/project/aislop/)
+[![Homebrew tap](https://img.shields.io/badge/Homebrew-scanaislop%2Ftap-2f855a.svg)](https://github.com/scanaislop/homebrew-tap)
 [![CI](https://github.com/scanaislop/aislop/actions/workflows/ci.yml/badge.svg)](https://github.com/scanaislop/aislop/actions/workflows/ci.yml)
 [![aislop score](https://badges.scanaislop.com/score/scanaislop/aislop.svg)](https://scanaislop.com/scanaislop/aislop)
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](https://opensource.org/licenses/MIT)
@@ -20,6 +22,16 @@ npx aislop@latest scan
 ```
 
 No install needed. Works on any project. Get your score in seconds.
+
+Prefer a persistent install? The same CLI ships through three channels:
+
+```bash
+brew install scanaislop/tap/aislop   # macOS / Linux (Homebrew)
+pipx install aislop                  # Python (pipx)
+npm install -g aislop                # Node (global)
+```
+
+See [Installation](#installation) for every option.
 
 ```bash
 aislop fix                   # auto-fix issues after installing
@@ -46,6 +58,10 @@ Run `npx aislop@latest badge` to auto-generate. Free at [scanaislop.com](https:/
 
 ## Installation
 
+The same CLI is published to npm, Homebrew, and PyPI. Pick whichever fits your stack.
+
+**Node / npm**
+
 ```bash
 # Run without installing
 npx aislop@latest scan
@@ -64,6 +80,24 @@ npm install -g aislop
 ```
 
 Also available as [`@scanaislop/aislop`](docs/installation.md) on GitHub Packages.
+
+**Homebrew** (macOS / Linux)
+
+```bash
+brew install scanaislop/tap/aislop
+```
+
+Homebrew installs Node.js as a dependency if it isn't already present. Details: [homebrew-tap](https://github.com/scanaislop/homebrew-tap).
+
+**Python / pipx**
+
+```bash
+pipx install aislop
+```
+
+`pipx` keeps `aislop` in its own isolated environment. Needs Node.js on `PATH`. Details: [PyPI package](https://pypi.org/project/aislop/).
+
+Full reference for every channel, bundled tooling, and external tools: [docs/installation.md](docs/installation.md).
 
 ---
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -1,5 +1,13 @@
 # Installation
 
+The same CLI is published to npm, Homebrew, and PyPI. Pick whichever fits your stack — every channel installs the identical `aislop` and `aislop-mcp` commands.
+
+| Channel | Command | Notes |
+|---|---|---|
+| npm / npx | `npx aislop@latest scan` | No install; bundles its own tooling |
+| Homebrew | `brew install scanaislop/tap/aislop` | macOS / Linux; pulls Node as a dependency |
+| Python / pipx | `pipx install aislop` | Isolated env; needs Node on `PATH` |
+
 ## Run without installing
 
 ```bash
@@ -33,6 +41,33 @@ The package is also published as `@scanaislop/aislop` on GitHub Packages:
 ```bash
 npm install --save-dev @scanaislop/aislop --registry=https://npm.pkg.github.com
 ```
+
+## Install with Homebrew
+
+macOS and Linux, via the official tap:
+
+```bash
+brew install scanaislop/tap/aislop
+```
+
+Equivalent two-step form:
+
+```bash
+brew tap scanaislop/tap
+brew install aislop
+```
+
+Homebrew installs Node.js as a runtime dependency if it isn't already present. Upgrade with `brew upgrade aislop`. More: [homebrew-tap](https://github.com/scanaislop/homebrew-tap).
+
+## Install with pipx (Python)
+
+For Python-tooling environments:
+
+```bash
+pipx install aislop
+```
+
+`pipx` keeps `aislop` in an isolated virtual environment. Plain `pip install --user aislop` also works. Both still require **Node.js** on `PATH`, since the engines run on Node. Upgrade with `pipx upgrade aislop`. More: [PyPI package](https://pypi.org/project/aislop/).
 
 ## Bundled tooling
 


### PR DESCRIPTION
Makes all three distribution channels (npm, Homebrew, PyPI) discoverable from the flagship README.

## Changes
- **Badges:** add PyPI downloads + Homebrew tap badges alongside npm
- **Quick start:** add a 3-channel install block (`brew install scanaislop/tap/aislop`, `pipx install aislop`, `npm install -g aislop`) under the npx hero
- **Installation:** restructured into Node/npm, Homebrew, and Python/pipx subsections
- **docs/installation.md:** channel-comparison table + dedicated Homebrew and pipx sections

Companion PRs expand the Homebrew tap and PyPI READMEs to match. Branched off `develop` (unrelated codex calibration work excluded).