### PR TITLE
chore: rename Action to 'aislop — AI Code Quality Gate'

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -1,4 +1,4 @@
-name: aislop Quality Gate
+name: aislop — AI Code Quality Gate
 description: Run the aislop quality gate on AI-assisted code (scan + fail CI below threshold from .aislop/config.yml).
 author: Kenny Olawuwo
 branding:

--- a/action.yml
+++ b/action.yml
@@ -1,6 +1,6 @@
 name: aislop — AI Code Quality Gate
 description: Run the aislop quality gate on AI-assisted code (scan + fail CI below threshold from .aislop/config.yml).
-author: Kenny Olawuwo
+author: scanaislop
 branding:
   icon: shield
   color: green


### PR DESCRIPTION
Aligns the Marketplace **Action** title with the chosen listing name (`aislop — AI Code Quality Gate`).

- `action.yml` `name` only — the published Marketplace slug (`/marketplace/actions/aislop-quality-gate`) is derived at first publish and is unaffected by a display-name change, so existing links keep working.
- Brand model: **aislop** = the tool/Action, **scanaislop** = the publisher/platform (shown automatically as 'By scanaislop').