### PR TITLE
feat(scan): expose forceFixable flag on findings

### DIFF
--- a/src/output/finding-assessment.ts
+++ b/src/output/finding-assessment.ts
@@ -16,7 +16,20 @@ export interface FindingAssessment {
 
 export interface AssessedDiagnostic extends Diagnostic {
 	assessment: FindingAssessment;
+	forceFixable: boolean;
 }
+
+// Findings that `aislop fix` leaves alone but `aislop fix -f` resolves (dependency
+// overrides, unused-file/dep pruning). Exposed so consumers need not parse help text.
+const FORCE_FIXABLE_RULES = new Set([
+	"security/vulnerable-dependency",
+	"knip/files",
+	"knip/dependencies",
+	"knip/devDependencies",
+]);
+
+export const isForceFixable = (diagnostic: Diagnostic): boolean =>
+	!diagnostic.fixable && FORCE_FIXABLE_RULES.has(diagnostic.rule);
 
 export interface FindingAssessmentRow {
 	kind: FindingKind;
@@ -107,6 +120,7 @@ export const withFindingAssessments = (diagnostics: Diagnostic[]): AssessedDiagn
 	diagnostics.map((diagnostic) => ({
 		...diagnostic,
 		assessment: assessDiagnostic(diagnostic),
+		forceFixable: isForceFixable(diagnostic),
 	}));
 
 export const summarizeFindingAssessments = (

--- a/src/output/finding-assessment.ts
+++ b/src/output/finding-assessment.ts
@@ -19,17 +19,24 @@ export interface AssessedDiagnostic extends Diagnostic {
 	forceFixable: boolean;
 }
 
-// Findings that `aislop fix` leaves alone but `aislop fix -f` resolves (dependency
-// overrides, unused-file/dep pruning). Exposed so consumers need not parse help text.
-const FORCE_FIXABLE_RULES = new Set([
-	"security/vulnerable-dependency",
-	"knip/files",
-	"knip/dependencies",
-	"knip/devDependencies",
-]);
+// Unused files/deps — `aislop fix -f` prunes these in any project.
+const KNIP_FORCE_RULES = new Set(["knip/files", "knip/dependencies", "knip/devDependencies"]);
 
-export const isForceFixable = (diagnostic: Diagnostic): boolean =>
-	!diagnostic.fixable && FORCE_FIXABLE_RULES.has(diagnostic.rule);
+// Findings that `aislop fix` leaves alone but `aislop fix -f` resolves. Gated by context,
+// not just rule id, so we never advertise a force fix that would be a no-op.
+export const isForceFixable = (diagnostic: Diagnostic): boolean => {
+	if (diagnostic.fixable) return false;
+	if (KNIP_FORCE_RULES.has(diagnostic.rule)) return true;
+	// Only JS audits have a force-fix path (pnpm.overrides / npm audit fix); pip/govulncheck/cargo do not.
+	if (diagnostic.rule === "security/vulnerable-dependency") {
+		return diagnostic.detail === "npm" || diagnostic.detail === "pnpm";
+	}
+	// Expo dependency alignment runs under `-f` (expo install --fix); the config error is not a dep fix.
+	if (diagnostic.rule.startsWith("expo-doctor/")) {
+		return diagnostic.rule !== "expo-doctor/config-error";
+	}
+	return false;
+};
 
 export interface FindingAssessmentRow {
 	kind: FindingKind;

--- a/src/output/finding-assessment.ts
+++ b/src/output/finding-assessment.ts
@@ -19,19 +19,15 @@ export interface AssessedDiagnostic extends Diagnostic {
 	forceFixable: boolean;
 }
 
-// Unused files/deps — `aislop fix -f` prunes these in any project.
 const KNIP_FORCE_RULES = new Set(["knip/files", "knip/dependencies", "knip/devDependencies"]);
 
-// Findings that `aislop fix` leaves alone but `aislop fix -f` resolves. Gated by context,
-// not just rule id, so we never advertise a force fix that would be a no-op.
 export const isForceFixable = (diagnostic: Diagnostic): boolean => {
 	if (diagnostic.fixable) return false;
 	if (KNIP_FORCE_RULES.has(diagnostic.rule)) return true;
-	// Only JS audits have a force-fix path (pnpm.overrides / npm audit fix); pip/govulncheck/cargo do not.
+	// Only JS audits have a `fix -f` path; pip/govulncheck/cargo do not.
 	if (diagnostic.rule === "security/vulnerable-dependency") {
 		return diagnostic.detail === "npm" || diagnostic.detail === "pnpm";
 	}
-	// Expo dependency alignment runs under `-f` (expo install --fix); the config error is not a dep fix.
 	if (diagnostic.rule.startsWith("expo-doctor/")) {
 		return diagnostic.rule !== "expo-doctor/config-error";
 	}

--- a/tests/force-fixable.test.ts
+++ b/tests/force-fixable.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from "vitest";
+import type { Diagnostic } from "../src/engines/types.js";
+import { isForceFixable, withFindingAssessments } from "../src/output/finding-assessment.js";
+
+const diag = (over: Partial<Diagnostic>): Diagnostic => ({
+	filePath: "package.json",
+	engine: "security",
+	rule: "security/vulnerable-dependency",
+	severity: "warning",
+	message: "",
+	help: "",
+	line: 0,
+	column: 0,
+	category: "Security",
+	fixable: false,
+	...over,
+});
+
+describe("isForceFixable", () => {
+	it("flags dependency vulnerabilities (fix -f only) as force-fixable", () => {
+		expect(isForceFixable(diag({}))).toBe(true);
+	});
+
+	it("flags knip unused files/deps as force-fixable", () => {
+		expect(isForceFixable(diag({ engine: "code-quality", rule: "knip/files" }))).toBe(true);
+	});
+
+	it("does not flag a normally auto-fixable finding", () => {
+		expect(
+			isForceFixable(diag({ engine: "ai-slop", rule: "ai-slop/unused-import", fixable: true })),
+		).toBe(false);
+	});
+
+	it("exposes forceFixable on assessed diagnostics for JSON output", () => {
+		const [assessed] = withFindingAssessments([diag({})]);
+		expect(assessed.forceFixable).toBe(true);
+	});
+});

--- a/tests/force-fixable.test.ts
+++ b/tests/force-fixable.test.ts
@@ -17,12 +17,24 @@ const diag = (over: Partial<Diagnostic>): Diagnostic => ({
 });
 
 describe("isForceFixable", () => {
-	it("flags dependency vulnerabilities (fix -f only) as force-fixable", () => {
-		expect(isForceFixable(diag({}))).toBe(true);
+	it("flags npm/pnpm dependency vulnerabilities", () => {
+		expect(isForceFixable(diag({ detail: "npm" }))).toBe(true);
+		expect(isForceFixable(diag({ detail: "pnpm" }))).toBe(true);
+	});
+
+	it("does NOT flag non-JS dependency vulnerabilities (pip/go/cargo have no fix -f path)", () => {
+		expect(isForceFixable(diag({ detail: undefined }))).toBe(false);
 	});
 
 	it("flags knip unused files/deps as force-fixable", () => {
 		expect(isForceFixable(diag({ engine: "code-quality", rule: "knip/files" }))).toBe(true);
+	});
+
+	it("flags expo dependency-alignment findings but not config errors", () => {
+		expect(
+			isForceFixable(diag({ engine: "lint", rule: "expo-doctor/check-dependency-versions" })),
+		).toBe(true);
+		expect(isForceFixable(diag({ engine: "lint", rule: "expo-doctor/config-error" }))).toBe(false);
 	});
 
 	it("does not flag a normally auto-fixable finding", () => {
@@ -32,7 +44,7 @@ describe("isForceFixable", () => {
 	});
 
 	it("exposes forceFixable on assessed diagnostics for JSON output", () => {
-		const [assessed] = withFindingAssessments([diag({})]);
+		const [assessed] = withFindingAssessments([diag({ detail: "npm" })]);
 		expect(assessed.forceFixable).toBe(true);
 	});
 });


### PR DESCRIPTION
Adds an explicit `forceFixable` boolean to each diagnostic in `scan --json`.

## Why
`security/vulnerable-dependency` (and `knip/files`,`knip/dependencies`,`knip/devDependencies`) are `fixable: false` because the default `aislop fix` never touches them — only `aislop fix -f` does. Consumers (the hosted platform) had to *guess* force-fixability from a hardcoded rule list + a help-text regex (whose own comment admits the wording moves between releases). This makes it first-class:

- New `isForceFixable(diagnostic)` + `forceFixable` on every assessed diagnostic, computed once from the rule id.
- Flows into `scan --json` automatically (diagnostics are spread into the output).

## Tests
`force-fixable.test.ts` (TDD): vuln deps + knip → true; normally-fixable → false; exposed on assessed diagnostics. Full suite 1099 passing, typecheck clean.