### PR TITLE
Release 0.11.0 → main

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## Unreleased
 
+## 0.11.0 (2026-06-06)
+
+PR-scoped quality gates and set-and-forget CI. `scan` and `ci` can now gate a pull request on only the files it changed (`--changes --base <ref>`), and an explicit base ref that cannot be resolved fails the run instead of silently passing an empty scan. A moving `v1` Action tag plus `version: latest` mean workflows never need a version bump, and every CI example now standardizes on Node 24.
+
 ### Added
 
 - **`--base <ref>` and `ci --changes`.** Both `scan` and `ci` now accept `--changes --base <ref>` to diff against a branch instead of `HEAD`, so a pull request can be gated on only the files it touches even when those files are already committed (a plain `--changes` diffs the working tree against `HEAD` and sees nothing in CI). `ci` also accepts `--changes` and `--staged` directly, applying the score gate and exit code to the scoped set. New Bitbucket Pipelines recipe in the docs uses `aislop ci --changes --base "origin/$BITBUCKET_PR_DESTINATION_BRANCH"`, removing the previous merge-base + soft-reset workaround ([#185](https://github.com/scanaislop/aislop/issues/185)).
@@ -14,6 +18,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 - **Set-and-forget CI.** A moving `v1` Action tag now tracks the latest release, so workflows can pin `uses: scanaislop/aislop@v1` instead of a per-release tag. `aislop init` generates a workflow using `@v1` with `version: latest`, and the CI docs lead with `npx --yes aislop@latest ci`. The release pipeline re-points `v1` automatically on each published release.
 - **Node standardized on 24.** `.nvmrc`, the Action's default `node-version`, and every CI docs example now use Node 24. The supported runtime floor is unchanged (`engines: ">=20"`).
+- **Marketplace Action renamed** to `aislop — AI Code Quality Gate`, published by `scanaislop`. Display metadata only; the action slug is unchanged.
 
 ## 0.10.2 (2026-06-02)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ PR-scoped quality gates and set-and-forget CI. `scan` and `ci` can now gate a pu
 ### Added
 
 - **`--base <ref>` and `ci --changes`.** Both `scan` and `ci` now accept `--changes --base <ref>` to diff against a branch instead of `HEAD`, so a pull request can be gated on only the files it touches even when those files are already committed (a plain `--changes` diffs the working tree against `HEAD` and sees nothing in CI). `ci` also accepts `--changes` and `--staged` directly, applying the score gate and exit code to the scoped set. New Bitbucket Pipelines recipe in the docs uses `aislop ci --changes --base "origin/$BITBUCKET_PR_DESTINATION_BRANCH"`, removing the previous merge-base + soft-reset workaround ([#185](https://github.com/scanaislop/aislop/issues/185)).
+- **`forceFixable` flag.** `scan --json` diagnostics now carry an explicit `forceFixable` boolean for findings that only `aislop fix -f` resolves (npm/pnpm dependency vulnerabilities, unused files/deps, Expo dependency alignment), so tools can surface a force-fix action without parsing help text ([#192](https://github.com/scanaislop/aislop/pull/192)).
 
 ### Changed
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aislop",
-  "version": "0.10.2",
+  "version": "0.11.0",
   "description": "Catch the slop AI coding agents leave in your code: narrative comments, swallowed exceptions, as-any casts, dead code, oversized functions. 50+ rules across 8 language targets (TypeScript, JavaScript, Expo / React Native, Python, Go, Rust, Ruby, PHP). Sub-second, deterministic, no LLM at runtime. MIT-licensed.",
   "type": "module",
   "bin": {

--- a/src/output/finding-assessment.ts
+++ b/src/output/finding-assessment.ts
@@ -16,7 +16,23 @@ export interface FindingAssessment {
 
 export interface AssessedDiagnostic extends Diagnostic {
 	assessment: FindingAssessment;
+	forceFixable: boolean;
 }
+
+const KNIP_FORCE_RULES = new Set(["knip/files", "knip/dependencies", "knip/devDependencies"]);
+
+export const isForceFixable = (diagnostic: Diagnostic): boolean => {
+	if (diagnostic.fixable) return false;
+	if (KNIP_FORCE_RULES.has(diagnostic.rule)) return true;
+	// Only JS audits have a `fix -f` path; pip/govulncheck/cargo do not.
+	if (diagnostic.rule === "security/vulnerable-dependency") {
+		return diagnostic.detail === "npm" || diagnostic.detail === "pnpm";
+	}
+	if (diagnostic.rule.startsWith("expo-doctor/")) {
+		return diagnostic.rule !== "expo-doctor/config-error";
+	}
+	return false;
+};
 
 export interface FindingAssessmentRow {
 	kind: FindingKind;
@@ -107,6 +123,7 @@ export const withFindingAssessments = (diagnostics: Diagnostic[]): AssessedDiagn
 	diagnostics.map((diagnostic) => ({
 		...diagnostic,
 		assessment: assessDiagnostic(diagnostic),
+		forceFixable: isForceFixable(diagnostic),
 	}));
 
 export const summarizeFindingAssessments = (

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,1 +1,1 @@
-export const APP_VERSION = process.env.VERSION ?? "0.10.2";
+export const APP_VERSION = process.env.VERSION ?? "0.11.0";

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,1 +1,16 @@
-export const APP_VERSION = process.env.VERSION ?? "0.11.0";
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const versionFromPackageJson = (): string => {
+	try {
+		const dir = dirname(fileURLToPath(import.meta.url));
+		return (JSON.parse(readFileSync(join(dir, "../package.json"), "utf8")) as { version: string })
+			.version;
+	} catch {
+		return "0.0.0";
+	}
+};
+
+// Bundled builds inject VERSION from package.json; the fallback keeps source/dev runs in sync.
+export const APP_VERSION = process.env.VERSION ?? versionFromPackageJson();

--- a/tests/cli-ergonomics.test.ts
+++ b/tests/cli-ergonomics.test.ts
@@ -40,7 +40,7 @@ describe("cli ergonomics", () => {
 		const result = runCli(["version"]);
 
 		expect(result.status).toBe(0);
-		expect(result.stdout.trim()).toBe("0.10.2");
+		expect(result.stdout.trim()).toBe("0.11.0");
 		expect(result.stderr).not.toContain("Path does not exist");
 	});
 
@@ -48,7 +48,7 @@ describe("cli ergonomics", () => {
 		const result = runCli(["-V"]);
 
 		expect(result.status).toBe(0);
-		expect(result.stdout.trim()).toBe("0.10.2");
+		expect(result.stdout.trim()).toBe("0.11.0");
 		expect(result.stderr).not.toContain("unknown option");
 	});
 

--- a/tests/cli-ergonomics.test.ts
+++ b/tests/cli-ergonomics.test.ts
@@ -1,8 +1,12 @@
 import { spawnSync } from "node:child_process";
+import { readFileSync } from "node:fs";
 import path from "node:path";
 import { describe, expect, it } from "vitest";
 
 const CLI = path.resolve("dist/cli.js");
+const PKG_VERSION = (
+	JSON.parse(readFileSync(path.resolve("package.json"), "utf8")) as { version: string }
+).version;
 
 const runCli = (args: string[]) =>
 	spawnSync(process.execPath, [CLI, ...args], {
@@ -40,7 +44,7 @@ describe("cli ergonomics", () => {
 		const result = runCli(["version"]);
 
 		expect(result.status).toBe(0);
-		expect(result.stdout.trim()).toBe("0.11.0");
+		expect(result.stdout.trim()).toBe(PKG_VERSION);
 		expect(result.stderr).not.toContain("Path does not exist");
 	});
 
@@ -48,7 +52,7 @@ describe("cli ergonomics", () => {
 		const result = runCli(["-V"]);
 
 		expect(result.status).toBe(0);
-		expect(result.stdout.trim()).toBe("0.11.0");
+		expect(result.stdout.trim()).toBe(PKG_VERSION);
 		expect(result.stderr).not.toContain("unknown option");
 	});
 

--- a/tests/force-fixable.test.ts
+++ b/tests/force-fixable.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from "vitest";
+import type { Diagnostic } from "../src/engines/types.js";
+import { isForceFixable, withFindingAssessments } from "../src/output/finding-assessment.js";
+
+const diag = (over: Partial<Diagnostic>): Diagnostic => ({
+	filePath: "package.json",
+	engine: "security",
+	rule: "security/vulnerable-dependency",
+	severity: "warning",
+	message: "",
+	help: "",
+	line: 0,
+	column: 0,
+	category: "Security",
+	fixable: false,
+	...over,
+});
+
+describe("isForceFixable", () => {
+	it("flags npm/pnpm dependency vulnerabilities", () => {
+		expect(isForceFixable(diag({ detail: "npm" }))).toBe(true);
+		expect(isForceFixable(diag({ detail: "pnpm" }))).toBe(true);
+	});
+
+	it("does NOT flag non-JS dependency vulnerabilities (pip/go/cargo have no fix -f path)", () => {
+		expect(isForceFixable(diag({ detail: undefined }))).toBe(false);
+	});
+
+	it("flags knip unused files/deps as force-fixable", () => {
+		expect(isForceFixable(diag({ engine: "code-quality", rule: "knip/files" }))).toBe(true);
+	});
+
+	it("flags expo dependency-alignment findings but not config errors", () => {
+		expect(
+			isForceFixable(diag({ engine: "lint", rule: "expo-doctor/check-dependency-versions" })),
+		).toBe(true);
+		expect(isForceFixable(diag({ engine: "lint", rule: "expo-doctor/config-error" }))).toBe(false);
+	});
+
+	it("does not flag a normally auto-fixable finding", () => {
+		expect(
+			isForceFixable(diag({ engine: "ai-slop", rule: "ai-slop/unused-import", fixable: true })),
+		).toBe(false);
+	});
+
+	it("exposes forceFixable on assessed diagnostics for JSON output", () => {
+		const [assessed] = withFindingAssessments([diag({ detail: "npm" })]);
+		expect(assessed.forceFixable).toBe(true);
+	});
+});


### PR DESCRIPTION
Promotes 0.11.0 to `main`. **Do not merge until ready to release** — merging then publishing the draft `v0.11.0` release triggers npm publish, the `v1` tag re-point, and the Marketplace README refresh.

## Included
- PR-scoped gating: `scan`/`ci --changes --base <ref>` (+ hard fail on unresolved base) — #185
- `forceFixable` flag in `scan --json` — #192
- Set-and-forget CI: `@v1` tag + `version: latest`; `init` + docs; release pipeline re-points `v1`
- Node 24 standardization; version fallback now derived from package.json (no drift)
- Marketplace Action renamed to `aislop — AI Code Quality Gate` (author `scanaislop`)

## Release steps (yours)
1. Merge this PR (develop → main).
2. Publish the **draft `v0.11.0`** release → npm publish + `v1` re-point + Marketplace README refresh.
3. Then: Homebrew `update-formula.sh 0.11.0`, PyPI (aislop-py #6), marketing changelog (#117).