### PR TITLE
chore(release): re-apply 0.11.0 stragglers (version.ts permanent fix + changelog)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ PR-scoped quality gates and set-and-forget CI. `scan` and `ci` can now gate a pu
 ### Added
 
 - **`--base <ref>` and `ci --changes`.** Both `scan` and `ci` now accept `--changes --base <ref>` to diff against a branch instead of `HEAD`, so a pull request can be gated on only the files it touches even when those files are already committed (a plain `--changes` diffs the working tree against `HEAD` and sees nothing in CI). `ci` also accepts `--changes` and `--staged` directly, applying the score gate and exit code to the scoped set. New Bitbucket Pipelines recipe in the docs uses `aislop ci --changes --base "origin/$BITBUCKET_PR_DESTINATION_BRANCH"`, removing the previous merge-base + soft-reset workaround ([#185](https://github.com/scanaislop/aislop/issues/185)).
+- **`forceFixable` flag.** `scan --json` diagnostics now carry an explicit `forceFixable` boolean for findings that only `aislop fix -f` resolves (npm/pnpm dependency vulnerabilities, unused files/deps, Expo dependency alignment), so tools can surface a force-fix action without parsing help text ([#192](https://github.com/scanaislop/aislop/pull/192)).
 
 ### Changed
 

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,1 +1,16 @@
-export const APP_VERSION = process.env.VERSION ?? "0.11.0";
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const versionFromPackageJson = (): string => {
+	try {
+		const dir = dirname(fileURLToPath(import.meta.url));
+		return (JSON.parse(readFileSync(join(dir, "../package.json"), "utf8")) as { version: string })
+			.version;
+	} catch {
+		return "0.0.0";
+	}
+};
+
+// Bundled builds inject VERSION from package.json; the fallback keeps source/dev runs in sync.
+export const APP_VERSION = process.env.VERSION ?? versionFromPackageJson();

--- a/tests/cli-ergonomics.test.ts
+++ b/tests/cli-ergonomics.test.ts
@@ -1,8 +1,12 @@
 import { spawnSync } from "node:child_process";
+import { readFileSync } from "node:fs";
 import path from "node:path";
 import { describe, expect, it } from "vitest";
 
 const CLI = path.resolve("dist/cli.js");
+const PKG_VERSION = (
+	JSON.parse(readFileSync(path.resolve("package.json"), "utf8")) as { version: string }
+).version;
 
 const runCli = (args: string[]) =>
 	spawnSync(process.execPath, [CLI, ...args], {
@@ -40,7 +44,7 @@ describe("cli ergonomics", () => {
 		const result = runCli(["version"]);
 
 		expect(result.status).toBe(0);
-		expect(result.stdout.trim()).toBe("0.11.0");
+		expect(result.stdout.trim()).toBe(PKG_VERSION);
 		expect(result.stderr).not.toContain("Path does not exist");
 	});
 
@@ -48,7 +52,7 @@ describe("cli ergonomics", () => {
 		const result = runCli(["-V"]);
 
 		expect(result.status).toBe(0);
-		expect(result.stdout.trim()).toBe("0.11.0");
+		expect(result.stdout.trim()).toBe(PKG_VERSION);
 		expect(result.stderr).not.toContain("unknown option");
 	});
 


### PR DESCRIPTION
These three changes landed on `chore/release-0.11.0` *after* #191 was squash-merged, so they never reached `develop`:
- **version.ts**: derive the fallback from package.json (the permanent, drift-proof fix) — develop still had the hardcoded `?? "0.11.0"`
- **cli-ergonomics test**: assert against `package.json` version instead of a literal
- **CHANGELOG**: the `forceFixable` (#192) bullet under 0.11.0

dist reports 0.11.0, fallback dead-code-eliminated from the bundle, typecheck clean, 15 tests pass.