### PR TITLE
Release v0.12.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,11 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## Unreleased
 
-### Fixed
-
-- **Agent telemetry coverage.** `aislop agent` and its provider, plan, monitor, session, apply, watch, and stop subcommands now emit the same `cli_command_started` / `cli_command_completed` lifecycle events as the rest of the CLI. Events include only aggregate provider/options/outcome fields; paths, branch names, session ids, prompts, raw findings, and transcripts stay local.
-
-## 0.12.0 (2026-06-08)
+## 0.12.0 (2026-06-10)
 
 Local agent repair sessions get a full terminal-native workflow, CLI output is tighter across the command surface, and scoring now separates cosmetic cleanup from higher-impact findings.
 
@@ -29,6 +25,7 @@ Local agent repair sessions get a full terminal-native workflow, CLI output is t
 
 ### Fixed
 
+- **Agent telemetry coverage.** `aislop agent` and its provider, plan, monitor, session, apply, watch, and stop subcommands now emit the same `cli_command_started` / `cli_command_completed` lifecycle events as the rest of the CLI. Events include only aggregate provider/options/outcome fields; paths, branch names, session ids, prompts, raw findings, and transcripts stay local.
 - **Agent subdirectory scope.** `aislop agent`, `agent plan`, and monitor repair now honor a requested subdirectory in monorepos instead of scanning/fixing the repository root.
 - **Background stop handling.** Monitor stop now signals the monitor process group on non-Windows platforms, matching background session stop behavior so active provider subprocesses are not left editing.
 - **Installer and CI stability.** Tool downloads retry transient GitHub/network failures, the TUI dependency stays compatible with the documented Node `>=20` floor, and long CLI help-surface tests have explicit CI-safe timeouts.
@@ -36,7 +33,7 @@ Local agent repair sessions get a full terminal-native workflow, CLI output is t
 
 ### Tests
 
-Full suite at 1228 passing, plus self-scan at 100 with zero diagnostics. New coverage locks the agent TUI, session state/activity, provider flows, background monitor lifecycle, scoped agent directories, rule impact metadata, command suggestions, source filtering, and calibration regressions.
+Full suite at 1271 passing, plus self-scan at 100 with zero diagnostics. New coverage locks the agent TUI, session state/activity, provider flows, background monitor lifecycle, scoped agent directories, rule impact metadata, command suggestions, source filtering, and calibration regressions.
 
 ## 0.11.0 (2026-06-06)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,7 +33,7 @@ Local agent repair sessions get a full terminal-native workflow, CLI output is t
 
 ### Tests
 
-Full suite at 1271 passing, plus self-scan at 100 with zero diagnostics. New coverage locks the agent TUI, session state/activity, provider flows, background monitor lifecycle, scoped agent directories, rule impact metadata, command suggestions, source filtering, and calibration regressions.
+Full suite at 1273 passing, plus self-scan at 100 with zero diagnostics. New coverage locks the agent TUI, session state/activity, provider flows, background monitor lifecycle, scoped agent directories, rule impact metadata, command suggestions, source filtering, and calibration regressions.
 
 ## 0.11.0 (2026-06-06)
 

--- a/src/agents/worktree.ts
+++ b/src/agents/worktree.ts
@@ -25,6 +25,58 @@ const readDirty = async (gitRoot: string): Promise<boolean> => {
 	return status.stdout.trim().length > 0;
 };
 
+const splitNull = (value: string): string[] => value.split("\0").filter(Boolean);
+
+const unique = (values: string[]): string[] => [...new Set(values)];
+
+const parseStatusPaths = (stdout: string): string[] => {
+	const records = splitNull(stdout);
+	const paths: string[] = [];
+	for (let index = 0; index < records.length; index += 1) {
+		const record = records[index] ?? "";
+		const status = record.slice(0, 2);
+		const filePath = record.slice(3);
+		if (!filePath) continue;
+		paths.push(filePath);
+		if (status.includes("R") || status.includes("C")) index += 1;
+	}
+	return unique(paths);
+};
+
+const readUntrackedFiles = async (cwd: string): Promise<string[]> => {
+	const result = await runSubprocess("git", ["ls-files", "--others", "--exclude-standard", "-z"], {
+		cwd,
+	});
+	if (result.exitCode !== 0) return [];
+	return splitNull(result.stdout);
+};
+
+const runGit = async (cwd: string, args: string[], timeout?: number): Promise<string> => {
+	const result = await runSubprocess("git", args, { cwd, timeout });
+	if (result.exitCode !== 0) throw new Error(result.stderr || `git ${args.join(" ")} failed.`);
+	return result.stdout;
+};
+
+const readDiffIncludingUntracked = async (
+	cwd: string,
+	args: string[],
+	timeout?: number,
+): Promise<string> => {
+	const untrackedFiles = await readUntrackedFiles(cwd);
+	const cached = await runGit(cwd, ["diff", "--cached", ...args], timeout);
+	if (untrackedFiles.length === 0) {
+		const worktree = await runGit(cwd, ["diff", ...args], timeout);
+		return [cached, worktree].filter(Boolean).join("\n");
+	}
+	await runGit(cwd, ["add", "--intent-to-add", "--", ...untrackedFiles], timeout);
+	try {
+		const worktree = await runGit(cwd, ["diff", ...args], timeout);
+		return [cached, worktree].filter(Boolean).join("\n");
+	} finally {
+		await runGit(cwd, ["reset", "--", ...untrackedFiles], timeout);
+	}
+};
+
 const readGitState = async (cwd: string): Promise<GitState> => {
 	const root = await runSubprocess("git", ["rev-parse", "--show-toplevel"], { cwd });
 	if (root.exitCode !== 0 || !root.stdout) {
@@ -130,9 +182,9 @@ export const removeAgentWorktree = async (worktree: AgentWorktree): Promise<void
 };
 
 export const diffNameOnly = async (cwd: string): Promise<string[]> => {
-	const result = await runSubprocess("git", ["diff", "--name-only"], { cwd });
+	const result = await runSubprocess("git", ["status", "--porcelain=v1", "-z"], { cwd });
 	if (result.exitCode !== 0) return [];
-	return result.stdout.split("\n").filter(Boolean);
+	return parseStatusPaths(result.stdout);
 };
 
 export interface DiffNumstat {
@@ -149,30 +201,35 @@ const parseNumstatValue = (value: string): number | null => {
 };
 
 export const diffNumstat = async (cwd: string): Promise<Map<string, DiffNumstat>> => {
-	const result = await runSubprocess("git", ["diff", "--numstat"], { cwd });
+	const stdout = await readDiffIncludingUntracked(cwd, ["--numstat"]);
 	const stats = new Map<string, DiffNumstat>();
-	if (result.exitCode !== 0) return stats;
-	for (const line of result.stdout.split("\n")) {
+	for (const line of stdout.split("\n")) {
 		if (!line.trim()) continue;
 		const [rawAdditions, rawDeletions, ...pathParts] = line.split("\t");
 		const filePath = pathParts.join("\t");
 		if (!filePath) continue;
 		const additions = parseNumstatValue(rawAdditions ?? "");
 		const deletions = parseNumstatValue(rawDeletions ?? "");
+		const existing = stats.get(filePath);
 		stats.set(filePath, {
 			filePath,
-			additions,
-			deletions,
-			binary: additions === null || deletions === null,
+			additions:
+				existing?.additions === null || additions === null
+					? null
+					: (existing?.additions ?? 0) + additions,
+			deletions:
+				existing?.deletions === null || deletions === null
+					? null
+					: (existing?.deletions ?? 0) + deletions,
+			binary: existing?.binary === true || additions === null || deletions === null,
 		});
 	}
 	return stats;
 };
 
 export const readBinaryDiff = async (cwd: string): Promise<string> => {
-	const result = await runSubprocess("git", ["diff", "--binary"], { cwd, timeout: 60_000 });
-	if (result.exitCode !== 0) throw new Error(result.stderr || "Failed to read worktree diff.");
+	const patch = await readDiffIncludingUntracked(cwd, ["--binary"], 60_000);
 	// runSubprocess trims trailing whitespace, but `git apply` is byte-strict and
 	// rejects a patch missing its final newline ("corrupt patch at line N").
-	return result.stdout.length > 0 ? `${result.stdout}\n` : result.stdout;
+	return patch.length > 0 ? `${patch}\n` : patch;
 };

--- a/src/commands/agent-watch.ts
+++ b/src/commands/agent-watch.ts
@@ -161,7 +161,6 @@ export const agentWatchCommand = async (
 							events,
 						}).join("\n")}\n`,
 					);
-					printedReview = true;
 				}
 				return;
 			}

--- a/src/mcp/tools.ts
+++ b/src/mcp/tools.ts
@@ -242,7 +242,10 @@ export const handleAislopWhy = (input: z.infer<typeof aislopWhyInputSchema>) => 
 };
 
 export const aislopBaselineInputSchema = z.object({
-	path: z.string().optional().describe("Project directory, confined to the MCP server's cwd. Defaults to that cwd."),
+	path: z
+		.string()
+		.optional()
+		.describe("Project directory, confined to the MCP server's cwd. Defaults to that cwd."),
 });
 
 export const aislopBaselineTool = {

--- a/tests/agents/worktree.test.ts
+++ b/tests/agents/worktree.test.ts
@@ -13,8 +13,10 @@ import path from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
 import {
 	createAgentWorktree,
+	diffNameOnly,
 	diffNumstat,
 	readAgentRoot,
+	readBinaryDiff,
 	removeAgentWorktree,
 } from "../../src/agents/worktree.js";
 
@@ -22,6 +24,13 @@ let tempDirs: string[] = [];
 
 const git = (cwd: string, args: string[]): void => {
 	const result = spawnSync("git", args, { cwd, encoding: "utf-8" });
+	if (result.status !== 0) {
+		throw new Error(result.stderr || result.stdout || `git ${args.join(" ")} failed`);
+	}
+};
+
+const gitWithInput = (cwd: string, args: string[], input: string): void => {
+	const result = spawnSync("git", args, { cwd, input, encoding: "utf-8" });
 	if (result.status !== 0) {
 		throw new Error(result.stderr || result.stdout || `git ${args.join(" ")} failed`);
 	}
@@ -91,5 +100,30 @@ describe("agent worktrees", () => {
 			deletions: 1,
 			binary: false,
 		});
+	});
+
+	it("lists staged and untracked files as agent worktree changes", async () => {
+		const root = createRepo();
+		writeFileSync(path.join(root, "index.ts"), "export const value = 2;\n", "utf-8");
+		git(root, ["add", "index.ts"]);
+		writeFileSync(path.join(root, "new.ts"), "export const added = true;\n", "utf-8");
+
+		await expect(diffNameOnly(root)).resolves.toEqual(["index.ts", "new.ts"]);
+	});
+
+	it("reads staged and untracked files into an applyable patch", async () => {
+		const root = createRepo();
+		writeFileSync(path.join(root, "index.ts"), "export const value = 2;\n", "utf-8");
+		git(root, ["add", "index.ts"]);
+		writeFileSync(path.join(root, "new.ts"), "export const added = true;\n", "utf-8");
+		const target = mkdtempSync(path.join(tmpdir(), "aislop-agent-worktree-target-"));
+		tempDirs.push(target);
+		git(root, ["clone", root, target]);
+
+		const patch = await readBinaryDiff(root);
+		gitWithInput(target, ["apply"], patch);
+
+		expect(readFileSync(path.join(target, "index.ts"), "utf-8")).toBe("export const value = 2;\n");
+		expect(readFileSync(path.join(target, "new.ts"), "utf-8")).toBe("export const added = true;\n");
 	});
 });


### PR DESCRIPTION
## Summary
- prepare the `develop` release train for `aislop@0.12.0` before the final `develop` -> `main` promotion
- refresh the 0.12.0 changelog date and include all release-train fixes in the 0.12.0 notes
- apply the formatter fix required by the release self-scan
- address PR review feedback around agent session diffs so staged and untracked provider edits are detected, patchable, and not discarded during cleanup

## Release notes
- adds the terminal-native `aislop agent` workflow and related session/provider commands
- improves command output, scoring calibration, source filtering, and rule impact metadata
- fixes agent scope/stop behavior, installer stability, telemetry coverage, Python/Go calibration regressions, and agent worktree diff detection

## Validation
- `pnpm install --frozen-lockfile`
- `pnpm vitest run tests/agents/worktree.test.ts tests/agents/watch.test.ts tests/agents/session-steps.test.ts tests/agents/apply.test.ts`
- `pnpm quality` — 144 test files, 1273 tests, self-scan score 100, 0 diagnostics
- `npm pack --dry-run` — produced `aislop@0.12.0` package preview with 26 files
