### PR TITLE
Fix agent monitor debounce handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,7 +33,7 @@ Local agent repair sessions get a full terminal-native workflow, CLI output is t
 
 ### Tests
 
-Full suite at 1273 passing, plus self-scan at 100 with zero diagnostics. New coverage locks the agent TUI, session state/activity, provider flows, background monitor lifecycle, scoped agent directories, rule impact metadata, command suggestions, source filtering, and calibration regressions.
+Full suite at 1275 passing, plus self-scan at 100 with zero diagnostics. New coverage locks the agent TUI, session state/activity, provider flows, background monitor lifecycle, scoped agent directories, rule impact metadata, command suggestions, source filtering, and calibration regressions.
 
 ## 0.11.0 (2026-06-06)
 

--- a/src/commands/agent-monitor.ts
+++ b/src/commands/agent-monitor.ts
@@ -20,9 +20,20 @@ import type { AgentMonitorOptions } from "./agent-monitor-types.js";
 import { runAgentSession } from "./agent-session.js";
 import type { AgentOptions, AgentScanJson } from "./agent-types.js";
 
-interface GitChangeSnapshot {
+export interface GitChangeSnapshot {
 	signature: string;
 	files: string[];
+}
+
+interface MonitorDebounceState {
+	current: GitChangeSnapshot;
+	pending: GitChangeSnapshot | null;
+	changedAt: number;
+}
+
+interface MonitorDebounceUpdate extends MonitorDebounceState {
+	detected: boolean;
+	settled: GitChangeSnapshot | null;
 }
 
 interface MonitorCycleResult {
@@ -84,6 +95,50 @@ export const shouldMonitorRepair = (input: {
 	input.inPlace &&
 	input.findings > 0 &&
 	(input.score === null || input.score < input.targetScore);
+
+export const updateMonitorDebounceState = (input: {
+	current: GitChangeSnapshot;
+	pending: GitChangeSnapshot | null;
+	changedAt: number;
+	next: GitChangeSnapshot;
+	now: number;
+	debounce: number;
+}): MonitorDebounceUpdate => {
+	if (input.next.signature === input.current.signature) {
+		return {
+			current: input.current,
+			pending: null,
+			changedAt: 0,
+			detected: false,
+			settled: null,
+		};
+	}
+	if (input.pending?.signature !== input.next.signature) {
+		return {
+			current: input.current,
+			pending: input.next,
+			changedAt: input.now,
+			detected: true,
+			settled: null,
+		};
+	}
+	if (input.now - input.changedAt >= input.debounce) {
+		return {
+			current: input.pending,
+			pending: null,
+			changedAt: 0,
+			detected: false,
+			settled: input.pending,
+		};
+	}
+	return {
+		current: input.current,
+		pending: input.pending,
+		changedAt: input.changedAt,
+		detected: false,
+		settled: null,
+	};
+};
 
 const changedFilesText = (files: string[]): string => {
 	if (files.length === 0) return "no git changes";
@@ -287,17 +342,24 @@ const monitorLoop = async (input: {
 	let changedAt = 0;
 	for (;;) {
 		const next = await readGitChangeSnapshot(input.root);
-		if (next.signature !== current.signature) {
-			pending = next;
-			changedAt = Date.now();
+		const update = updateMonitorDebounceState({
+			current,
+			pending,
+			changedAt,
+			next,
+			now: Date.now(),
+			debounce: input.options.debounce,
+		});
+		current = update.current;
+		pending = update.pending;
+		changedAt = update.changedAt;
+		if (update.detected) {
 			log.info(`Change detected: ${changedFilesText(next.files)}`);
 		}
-		if (pending && Date.now() - changedAt >= input.options.debounce) {
-			current = pending;
-			pending = null;
+		if (update.settled) {
 			await runMonitorCycle({
 				...input,
-				snapshot: current,
+				snapshot: update.settled,
 				reason: "settled changes",
 			});
 		}

--- a/tests/agents/monitor.test.ts
+++ b/tests/agents/monitor.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it } from "vitest";
-import { parseGitStatusPaths, shouldMonitorRepair } from "../../src/commands/agent-monitor.js";
+import {
+	parseGitStatusPaths,
+	shouldMonitorRepair,
+	updateMonitorDebounceState,
+	type GitChangeSnapshot,
+} from "../../src/commands/agent-monitor.js";
 
 describe("agent monitor", () => {
 	it("parses porcelain git status paths for changed and renamed files", () => {
@@ -45,5 +50,71 @@ describe("agent monitor", () => {
 				findings: 2,
 			}),
 		).toBe(false);
+	});
+
+	it("does not restart debounce for the same pending snapshot", () => {
+		const current: GitChangeSnapshot = { signature: "", files: [] };
+		const changed: GitChangeSnapshot = { signature: " M src/a.ts\n", files: ["src/a.ts"] };
+		const first = updateMonitorDebounceState({
+			current,
+			pending: null,
+			changedAt: 0,
+			next: changed,
+			now: 100,
+			debounce: 1_000,
+		});
+		expect(first.detected).toBe(true);
+		expect(first.pending).toBe(changed);
+		expect(first.changedAt).toBe(100);
+
+		const stillPending = updateMonitorDebounceState({
+			current: first.current,
+			pending: first.pending,
+			changedAt: first.changedAt,
+			next: changed,
+			now: 800,
+			debounce: 1_000,
+		});
+		expect(stillPending.detected).toBe(false);
+		expect(stillPending.pending).toBe(changed);
+		expect(stillPending.changedAt).toBe(100);
+		expect(stillPending.settled).toBeNull();
+
+		const settled = updateMonitorDebounceState({
+			current: stillPending.current,
+			pending: stillPending.pending,
+			changedAt: stillPending.changedAt,
+			next: changed,
+			now: 1_101,
+			debounce: 1_000,
+		});
+		expect(settled.current).toBe(changed);
+		expect(settled.pending).toBeNull();
+		expect(settled.settled).toBe(changed);
+	});
+
+	it("clears pending debounce when changes return to the current snapshot", () => {
+		const current: GitChangeSnapshot = { signature: "", files: [] };
+		const changed: GitChangeSnapshot = { signature: " M src/a.ts\n", files: ["src/a.ts"] };
+		const first = updateMonitorDebounceState({
+			current,
+			pending: null,
+			changedAt: 0,
+			next: changed,
+			now: 100,
+			debounce: 1_000,
+		});
+		const reverted = updateMonitorDebounceState({
+			current: first.current,
+			pending: first.pending,
+			changedAt: first.changedAt,
+			next: current,
+			now: 500,
+			debounce: 1_000,
+		});
+		expect(reverted.current).toBe(current);
+		expect(reverted.pending).toBeNull();
+		expect(reverted.changedAt).toBe(0);
+		expect(reverted.settled).toBeNull();
 	});
 });


### PR DESCRIPTION
## Summary
- fix the agent monitor debounce loop so a stable pending snapshot does not keep resetting the debounce timer
- clear a pending debounce when the checkout returns to the current baseline before settling
- add focused regression coverage and update the v0.12.0 test count

## Review context
- Addresses the Codex review comment from #220: https://github.com/scanaislop/aislop/pull/220#discussion_r3392059449

## Validation
- pnpm exec vitest run tests/agents/monitor.test.ts tests/agents/monitor-lifecycle.test.ts tests/agents/monitor-store.test.ts
- pnpm quality
- node dist/cli.js scan --changes --json
- git diff --check