### PR TITLE
Preserve zero debounce monitor reactions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,7 +33,7 @@ Local agent repair sessions get a full terminal-native workflow, CLI output is t
 
 ### Tests
 
-Full suite at 1275 passing, plus self-scan at 100 with zero diagnostics. New coverage locks the agent TUI, session state/activity, provider flows, background monitor lifecycle, scoped agent directories, rule impact metadata, command suggestions, source filtering, and calibration regressions.
+Full suite at 1276 passing, plus self-scan at 100 with zero diagnostics. New coverage locks the agent TUI, session state/activity, provider flows, background monitor lifecycle, scoped agent directories, rule impact metadata, command suggestions, source filtering, and calibration regressions.
 
 ## 0.11.0 (2026-06-06)
 

--- a/src/commands/agent-monitor.ts
+++ b/src/commands/agent-monitor.ts
@@ -114,6 +114,15 @@ export const updateMonitorDebounceState = (input: {
 		};
 	}
 	if (input.pending?.signature !== input.next.signature) {
+		if (input.debounce <= 0) {
+			return {
+				current: input.next,
+				pending: null,
+				changedAt: 0,
+				detected: true,
+				settled: input.next,
+			};
+		}
 		return {
 			current: input.current,
 			pending: input.next,

--- a/tests/agents/monitor.test.ts
+++ b/tests/agents/monitor.test.ts
@@ -93,6 +93,24 @@ describe("agent monitor", () => {
 		expect(settled.settled).toBe(changed);
 	});
 
+	it("settles the first changed snapshot immediately when debounce is zero", () => {
+		const current: GitChangeSnapshot = { signature: "", files: [] };
+		const changed: GitChangeSnapshot = { signature: " M src/a.ts\n", files: ["src/a.ts"] };
+		const settled = updateMonitorDebounceState({
+			current,
+			pending: null,
+			changedAt: 0,
+			next: changed,
+			now: 100,
+			debounce: 0,
+		});
+		expect(settled.current).toBe(changed);
+		expect(settled.pending).toBeNull();
+		expect(settled.changedAt).toBe(0);
+		expect(settled.detected).toBe(true);
+		expect(settled.settled).toBe(changed);
+	});
+
 	it("clears pending debounce when changes return to the current snapshot", () => {
 		const current: GitChangeSnapshot = { signature: "", files: [] };
 		const changed: GitChangeSnapshot = { signature: " M src/a.ts\n", files: ["src/a.ts"] };


### PR DESCRIPTION
## Summary
- preserve instant monitor reactions when `--debounce 0` is used
- settle the first changed snapshot immediately for zero or negative debounce values
- add regression coverage and update the v0.12.0 test count

## Review context
- Addresses the Codex review comment from #222: https://github.com/scanaislop/aislop/pull/222#discussion_r3392119807

## Validation
- `pnpm exec vitest run tests/agents/monitor.test.ts tests/agents/monitor-lifecycle.test.ts tests/agents/monitor-store.test.ts`
- `pnpm quality`
- `node dist/cli.js scan --changes --json`
- `git diff --check`