### PR TITLE
Add framework adapter entrypoints

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,26 @@
     ".": {
       "types": "./dist/index.d.ts",
       "default": "./dist/index.js"
+    },
+    "./adapters/astro": {
+      "types": "./dist/adapters/astro.d.ts",
+      "default": "./dist/adapters/astro.js"
+    },
+    "./adapters/expo": {
+      "types": "./dist/adapters/expo.d.ts",
+      "default": "./dist/adapters/expo.js"
+    },
+    "./adapters/nuxt": {
+      "types": "./dist/adapters/nuxt.d.ts",
+      "default": "./dist/adapters/nuxt.js"
+    },
+    "./adapters/sveltekit": {
+      "types": "./dist/adapters/sveltekit.d.ts",
+      "default": "./dist/adapters/sveltekit.js"
+    },
+    "./adapters/vite": {
+      "types": "./dist/adapters/vite.d.ts",
+      "default": "./dist/adapters/vite.js"
     }
   },
   "scripts": {

--- a/src/framework-adapters/astro.ts
+++ b/src/framework-adapters/astro.ts
@@ -1,0 +1,40 @@
+import {
+	type AislopAdapterOptions,
+	type AislopRunResult,
+	createAislopCiWorkflow,
+	createAislopPackageScripts,
+	maybeRunAislop,
+} from "./core.js";
+
+export interface AstroIntegration {
+	name: string;
+	hooks: {
+		"astro:build:start"?: () => Promise<void>;
+	};
+}
+
+export interface AislopAstroOptions extends AislopAdapterOptions {
+	runOnBuild?: boolean;
+}
+
+export const createAstroAislopScripts = (): Record<string, string> =>
+	createAislopPackageScripts("astro");
+
+export const createAstroAislopWorkflow = (): string => createAislopCiWorkflow();
+
+export const runAstroAislop = async (options: AislopAstroOptions = {}): Promise<AislopRunResult> =>
+	maybeRunAislop("astro", {
+		...options,
+		enabled: options.enabled ?? options.runOnBuild ?? false,
+	});
+
+const aislopAstro = (options: AislopAstroOptions = {}): AstroIntegration => ({
+	name: "@scanaislop/astro",
+	hooks: {
+		"astro:build:start": async () => {
+			await runAstroAislop(options);
+		},
+	},
+});
+
+export default aislopAstro;

--- a/src/framework-adapters/core.ts
+++ b/src/framework-adapters/core.ts
@@ -1,0 +1,163 @@
+import { spawn } from "node:child_process";
+import process from "node:process";
+
+export type AislopFramework =
+	| "astro"
+	| "expo"
+	| "nuxt"
+	| "sveltekit"
+	| "vite"
+	| "tanstack-start"
+	| "redwoodsdk"
+	| "t3";
+
+export type AislopAdapterCommand = "ci" | "scan";
+
+export interface AislopRunRequest {
+	framework: AislopFramework;
+	bin: string;
+	args: string[];
+	cwd: string;
+	env: NodeJS.ProcessEnv;
+}
+
+export interface AislopRunResult {
+	command: string;
+	args: string[];
+	exitCode: number | null;
+	signal: NodeJS.Signals | null;
+	skipped: boolean;
+}
+
+export type AislopRunner = (
+	request: AislopRunRequest,
+) => AislopRunResult | Promise<AislopRunResult>;
+
+export interface AislopAdapterOptions {
+	/**
+	 * Running during a framework build is opt-in so integrations never surprise
+	 * local dev servers or production builds.
+	 */
+	enabled?: boolean;
+	command?: AislopAdapterCommand;
+	args?: string[];
+	bin?: string;
+	cwd?: string;
+	env?: NodeJS.ProcessEnv;
+	failOnError?: boolean;
+	runner?: AislopRunner;
+}
+
+interface AislopPackageScriptsOptions {
+	command?: AislopAdapterCommand;
+	includeAgent?: boolean;
+	includeHook?: boolean;
+}
+
+const DEFAULT_ARGS: Record<AislopAdapterCommand, string[]> = {
+	ci: ["ci"],
+	scan: ["scan"],
+};
+
+export const resolveAislopRunRequest = (
+	framework: AislopFramework,
+	options: AislopAdapterOptions = {},
+): AislopRunRequest => {
+	const command = options.command ?? "ci";
+	const env = options.env ? { ...process.env, ...options.env } : { ...process.env };
+	return {
+		framework,
+		bin: options.bin ?? "aislop",
+		args: [...DEFAULT_ARGS[command], ...(options.args ?? [])],
+		cwd: options.cwd ?? process.cwd(),
+		env,
+	};
+};
+
+const runAislop = async (request: AislopRunRequest): Promise<AislopRunResult> =>
+	new Promise((resolve) => {
+		const child = spawn(request.bin, request.args, {
+			cwd: request.cwd,
+			env: request.env,
+			stdio: "inherit",
+		});
+
+		child.on("close", (exitCode, signal) => {
+			resolve({
+				command: request.bin,
+				args: request.args,
+				exitCode,
+				signal,
+				skipped: false,
+			});
+		});
+	});
+
+export const maybeRunAislop = async (
+	framework: AislopFramework,
+	options: AislopAdapterOptions = {},
+): Promise<AislopRunResult> => {
+	const request = resolveAislopRunRequest(framework, options);
+
+	if (options.enabled !== true) {
+		return {
+			command: request.bin,
+			args: request.args,
+			exitCode: 0,
+			signal: null,
+			skipped: true,
+		};
+	}
+
+	const result = await (options.runner ?? runAislop)(request);
+	if (options.failOnError !== false && !result.skipped && result.exitCode !== 0) {
+		throw new Error(
+			`aislop ${request.args.join(" ")} failed for ${framework} with exit code ${String(
+				result.exitCode,
+			)}`,
+		);
+	}
+
+	return result;
+};
+
+export const createAislopPackageScripts = (
+	_framework: AislopFramework,
+	options: AislopPackageScriptsOptions = {},
+): Record<string, string> => {
+	const command = options.command ?? "ci";
+	const scripts: Record<string, string> = {
+		"aislop:scan": "aislop scan",
+		"aislop:ci": `aislop ${command}`,
+	};
+
+	if (options.includeAgent ?? true) {
+		scripts["aislop:agent"] = "aislop agent";
+	}
+
+	if (options.includeHook ?? true) {
+		scripts["aislop:hook"] = "aislop hook install";
+	}
+
+	return scripts;
+};
+
+export const createAislopCiWorkflow = (
+	packageManagerCommand = "npx --yes aislop@latest ci",
+): string =>
+	[
+		"name: aislop",
+		"",
+		"on:",
+		"  pull_request:",
+		"  push:",
+		"    branches: [main]",
+		"",
+		"jobs:",
+		"  quality-gate:",
+		"    runs-on: ubuntu-latest",
+		"    steps:",
+		"      - uses: actions/checkout@v4",
+		`      - run: ${packageManagerCommand}`,
+		"",
+	].join("\n");

--- a/src/framework-adapters/expo.ts
+++ b/src/framework-adapters/expo.ts
@@ -1,0 +1,49 @@
+import {
+	type AislopAdapterOptions,
+	type AislopRunResult,
+	createAislopCiWorkflow,
+	createAislopPackageScripts,
+	maybeRunAislop,
+} from "./core.js";
+
+export interface ExpoConfigLike {
+	extra?: Record<string, unknown>;
+	[name: string]: unknown;
+}
+
+export interface AislopExpoOptions extends AislopAdapterOptions {
+	/**
+	 * Expo config plugins run while resolving app config. Keep scan execution out
+	 * of that path unless a host integration explicitly opts in.
+	 */
+	runDuringConfig?: boolean;
+}
+
+export const createExpoAislopScripts = (): Record<string, string> =>
+	createAislopPackageScripts("expo");
+
+export const createExpoAislopWorkflow = (): string => createAislopCiWorkflow();
+
+export const runExpoAislop = async (options: AislopExpoOptions = {}): Promise<AislopRunResult> =>
+	maybeRunAislop("expo", {
+		...options,
+		enabled: options.enabled ?? options.runDuringConfig ?? false,
+	});
+
+const withAislopExpo = <TConfig extends ExpoConfigLike>(
+	config: TConfig,
+	_options: AislopExpoOptions = {},
+): TConfig => {
+	const extra = {
+		...config.extra,
+		aislop: {
+			command: "npx --yes aislop@latest ci",
+			hook: "aislop hook install",
+			enabled: true,
+		},
+	};
+
+	return { ...config, extra };
+};
+
+export default withAislopExpo;

--- a/src/framework-adapters/nuxt.ts
+++ b/src/framework-adapters/nuxt.ts
@@ -1,0 +1,64 @@
+import {
+	type AislopAdapterOptions,
+	type AislopRunResult,
+	createAislopCiWorkflow,
+	createAislopPackageScripts,
+	maybeRunAislop,
+} from "./core.js";
+
+type NuxtHookName = "build:before" | "nitro:build:before";
+
+export interface NuxtLike {
+	hook?: (name: NuxtHookName, callback: () => Promise<void>) => void;
+	options?: {
+		runtimeConfig?: Record<string, unknown>;
+	};
+}
+
+export interface AislopNuxtOptions extends AislopAdapterOptions {
+	runOnBuild?: boolean;
+	hook?: NuxtHookName;
+}
+
+export interface NuxtModuleLike {
+	meta: {
+		name: string;
+		configKey: string;
+	};
+	defaults: AislopNuxtOptions;
+	setup: (options: AislopNuxtOptions, nuxt: NuxtLike) => void | Promise<void>;
+}
+
+const DEFAULTS: AislopNuxtOptions = {
+	command: "ci",
+	enabled: false,
+	failOnError: true,
+	hook: "build:before",
+};
+
+export const createNuxtAislopScripts = (): Record<string, string> =>
+	createAislopPackageScripts("nuxt");
+
+export const createNuxtAislopWorkflow = (): string => createAislopCiWorkflow();
+
+export const runNuxtAislop = async (options: AislopNuxtOptions = {}): Promise<AislopRunResult> =>
+	maybeRunAislop("nuxt", {
+		...options,
+		enabled: options.enabled ?? options.runOnBuild ?? false,
+	});
+
+export const createAislopNuxtModule = (defaults: AislopNuxtOptions = {}): NuxtModuleLike => ({
+	meta: {
+		name: "@scanaislop/nuxt",
+		configKey: "aislop",
+	},
+	defaults: { ...DEFAULTS, ...defaults },
+	setup(options, nuxt) {
+		const merged = { ...DEFAULTS, ...defaults, ...options };
+		nuxt.hook?.(merged.hook ?? "build:before", async () => {
+			await runNuxtAislop(merged);
+		});
+	},
+});
+
+export default createAislopNuxtModule();

--- a/src/framework-adapters/sveltekit.ts
+++ b/src/framework-adapters/sveltekit.ts
@@ -1,0 +1,22 @@
+import {
+	type AislopRunResult,
+	createAislopCiWorkflow,
+	createAislopPackageScripts,
+} from "./core.js";
+import aislopVite, { type AislopViteOptions, type VitePluginLike, runViteAislop } from "./vite.js";
+
+export type AislopSvelteKitOptions = Omit<AislopViteOptions, "framework">;
+
+export const createSvelteKitAislopScripts = (): Record<string, string> =>
+	createAislopPackageScripts("sveltekit");
+
+export const createSvelteKitAislopWorkflow = (): string => createAislopCiWorkflow();
+
+export const runSvelteKitAislop = async (
+	options: AislopSvelteKitOptions = {},
+): Promise<AislopRunResult> => runViteAislop({ ...options, framework: "sveltekit" });
+
+const aislopSvelteKit = (options: AislopSvelteKitOptions = {}): VitePluginLike =>
+	aislopVite({ ...options, framework: "sveltekit" });
+
+export default aislopSvelteKit;

--- a/src/framework-adapters/vite.ts
+++ b/src/framework-adapters/vite.ts
@@ -1,0 +1,59 @@
+import {
+	type AislopAdapterOptions,
+	type AislopFramework,
+	type AislopRunResult,
+	createAislopCiWorkflow,
+	createAislopPackageScripts,
+	maybeRunAislop,
+} from "./core.js";
+
+type ViteApply = "serve" | "build";
+
+export interface VitePluginLike {
+	name: string;
+	apply?: ViteApply;
+	buildStart?: () => Promise<void>;
+	closeBundle?: () => Promise<void>;
+}
+
+export interface AislopViteOptions extends AislopAdapterOptions {
+	framework?: Extract<
+		AislopFramework,
+		"vite" | "tanstack-start" | "redwoodsdk" | "t3" | "sveltekit"
+	>;
+	runOnBuild?: boolean;
+	hook?: "buildStart" | "closeBundle";
+}
+
+export const createViteAislopScripts = (
+	framework: AislopViteOptions["framework"] = "vite",
+): Record<string, string> => {
+	const scripts = createAislopPackageScripts(framework);
+	scripts["aislop:build-gate"] = "aislop ci --changes";
+	return scripts;
+};
+
+export const createViteAislopWorkflow = (): string => createAislopCiWorkflow();
+
+export const runViteAislop = async (options: AislopViteOptions = {}): Promise<AislopRunResult> => {
+	const framework = options.framework ?? "vite";
+	return maybeRunAislop(framework, {
+		...options,
+		enabled: options.enabled ?? options.runOnBuild ?? false,
+	});
+};
+
+const aislopVite = (options: AislopViteOptions = {}): VitePluginLike => {
+	const hook = options.hook ?? "closeBundle";
+	const run = async () => {
+		await runViteAislop(options);
+	};
+
+	return {
+		name: "aislop:vite",
+		apply: "build",
+		...(hook === "buildStart" ? { buildStart: run } : { closeBundle: run }),
+	};
+};
+
+export default aislopVite;

--- a/tests/framework-adapters.test.ts
+++ b/tests/framework-adapters.test.ts
@@ -1,0 +1,108 @@
+import { describe, expect, it } from "vitest";
+import {
+	createAislopCiWorkflow,
+	createAislopPackageScripts,
+	maybeRunAislop,
+	resolveAislopRunRequest,
+	type AislopRunRequest,
+} from "../src/framework-adapters/core.js";
+import aislopAstro, { createAstroAislopScripts } from "../src/framework-adapters/astro.js";
+import withAislopExpo from "../src/framework-adapters/expo.js";
+import { createAislopNuxtModule } from "../src/framework-adapters/nuxt.js";
+import aislopSvelteKit from "../src/framework-adapters/sveltekit.js";
+import aislopVite from "../src/framework-adapters/vite.js";
+
+const recordingRunner = (calls: AislopRunRequest[]) => async (request: AislopRunRequest) => {
+	calls.push(request);
+	return {
+		command: request.bin,
+		args: request.args,
+		exitCode: 0,
+		signal: null,
+		skipped: false,
+	};
+};
+
+describe("framework adapters", () => {
+	it("resolves aislop command defaults without enabling execution", async () => {
+		const request = resolveAislopRunRequest("astro", { args: ["--changes"] });
+
+		expect(request.bin).toBe("aislop");
+		expect(request.args).toEqual(["ci", "--changes"]);
+
+		const skipped = await maybeRunAislop("astro", { args: ["--changes"] });
+		expect(skipped).toMatchObject({
+			command: "aislop",
+			args: ["ci", "--changes"],
+			exitCode: 0,
+			skipped: true,
+		});
+	});
+
+	it("generates package scripts and a workflow snippet", () => {
+		expect(createAislopPackageScripts("expo")).toEqual({
+			"aislop:agent": "aislop agent",
+			"aislop:ci": "aislop ci",
+			"aislop:hook": "aislop hook install",
+			"aislop:scan": "aislop scan",
+		});
+		expect(createAislopCiWorkflow()).toContain("npx --yes aislop@latest ci");
+	});
+
+	it("builds an Astro integration with opt-in build execution", async () => {
+		const calls: AislopRunRequest[] = [];
+		const integration = aislopAstro({ enabled: true, runner: recordingRunner(calls) });
+
+		expect(integration.name).toBe("@scanaislop/astro");
+		expect(createAstroAislopScripts()["aislop:ci"]).toBe("aislop ci");
+
+		await integration.hooks["astro:build:start"]?.();
+		expect(calls).toHaveLength(1);
+		expect(calls[0]?.framework).toBe("astro");
+	});
+
+	it("merges Expo config metadata without removing existing extra values", () => {
+		const config = withAislopExpo({ name: "mobile", extra: { apiUrl: "https://example.test" } });
+
+		expect(config.extra?.apiUrl).toBe("https://example.test");
+		expect(config.extra?.aislop).toEqual({
+			command: "npx --yes aislop@latest ci",
+			enabled: true,
+			hook: "aislop hook install",
+		});
+	});
+
+	it("registers a Nuxt build hook and runs through the injected runner", async () => {
+		const calls: AislopRunRequest[] = [];
+		let callback: (() => Promise<void>) | null = null;
+		const module = createAislopNuxtModule({ enabled: true, runner: recordingRunner(calls) });
+
+		module.setup(
+			{},
+			{
+				hook(name, cb) {
+					expect(name).toBe("build:before");
+					callback = cb;
+				},
+			},
+		);
+
+		await callback?.();
+		expect(calls).toHaveLength(1);
+		expect(calls[0]?.framework).toBe("nuxt");
+	});
+
+	it("runs Vite and SvelteKit plugins through build hooks only when enabled", async () => {
+		const calls: AislopRunRequest[] = [];
+		const vite = aislopVite({ enabled: true, runner: recordingRunner(calls), hook: "buildStart" });
+		const svelte = aislopSvelteKit({ enabled: true, runner: recordingRunner(calls) });
+
+		expect(vite.name).toBe("aislop:vite");
+		expect(vite.apply).toBe("build");
+
+		await vite.buildStart?.();
+		await svelte.closeBundle?.();
+
+		expect(calls.map((call) => call.framework)).toEqual(["vite", "sveltekit"]);
+	});
+});

--- a/tsdown.config.ts
+++ b/tsdown.config.ts
@@ -23,6 +23,11 @@ export default defineConfig([
 	{
 		entry: {
 			index: "./src/index.ts",
+			"adapters/astro": "./src/framework-adapters/astro.ts",
+			"adapters/expo": "./src/framework-adapters/expo.ts",
+			"adapters/nuxt": "./src/framework-adapters/nuxt.ts",
+			"adapters/sveltekit": "./src/framework-adapters/sveltekit.ts",
+			"adapters/vite": "./src/framework-adapters/vite.ts",
 		},
 		external: ["oxlint", "knip", "knip/session", "@biomejs/biome", "typescript"],
 		dts: true,


### PR DESCRIPTION
## Summary
- add side-effect-free adapter entrypoints for Astro, Expo, Nuxt, SvelteKit, and Vite
- expose adapter subpaths through package exports and tsdown build entries
- add focused tests for command resolution, package scripts, workflow snippet generation, and framework hooks

## Verification
- pnpm typecheck
- pnpm exec vitest run tests/framework-adapters.test.ts
- pnpm build
- node dist/cli.js scan --changes --json → score 100, 0 diagnostics
- pnpm quality → 145 test files, 1282 tests, score 100, 0 diagnostics