### PR TITLE
chore(release): v0.12.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## Unreleased
 
+## 0.12.1 (2026-06-20)
+
+### Fixed
+
+- **Cross-platform build script.** `pnpm build` now works on Windows. Dropped the `rm -rf dist` and `NODE_ENV=` prefix (cmd.exe could not parse them, and a failed run wiped `dist` without rebuilding); tsdown cleans its output directory on its own and nothing reads `NODE_ENV`. Thanks @mtschoen. (#231)
+- **Dependency security advisories.** Bumped `vite` (>=7.3.5), `hono` (>=4.12.25), `esbuild` (>=0.28.1), and `tar` (>=7.5.16) to clear the high- and moderate-severity advisories the security engine flags on the project itself. (#232)
+
 ## 0.12.0 (2026-06-10)
 
 Local agent repair sessions get a full terminal-native workflow, CLI output is tighter across the command surface, and scoring now separates cosmetic cleanup from higher-impact findings.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aislop",
-  "version": "0.12.0",
+  "version": "0.12.1",
   "description": "Catch the slop AI coding agents leave in your code: narrative comments, swallowed exceptions, as-any casts, dead code, oversized functions. 50+ rules across 8 language targets (TypeScript, JavaScript, Expo / React Native, Python, Go, Rust, Ruby, PHP). Sub-second, deterministic, no LLM at runtime. MIT-licensed.",
   "type": "module",
   "bin": {


### PR DESCRIPTION
Patch release prep.

Bumps the version to **0.12.1** and adds the CHANGELOG section. Changes since 0.12.0:

- fix(build): cross-platform build script (#231)
- fix(deps): vite/hono/esbuild/tar security advisories (#232)

Only `package.json` (version) and `CHANGELOG.md` change; `src/version.ts` reads the version from package.json, and no docs hardcode it.

Verified: frozen install, typecheck, build, full test suite (1277 passed), self-scan 0 errors, `aislop --version` reports 0.12.1.