### PR TITLE
fix: azure namespace imports and bun audit support

### DIFF
--- a/src/commands/doctor.ts
+++ b/src/commands/doctor.ts
@@ -258,6 +258,7 @@ interface AuditSpec {
 
 const AUDIT_SPECS: AuditSpec[] = [
 	{ files: ["pnpm-lock.yaml"], bundled: "pnpm audit" },
+	{ files: ["bun.lock", "bun.lockb"], bundled: "bun audit" },
 	{ files: ["package-lock.json"], bundled: "npm audit" },
 	{
 		files: ["requirements.txt", "poetry.lock", "Pipfile.lock"],

--- a/src/engines/ai-slop/hallucinated-imports.ts
+++ b/src/engines/ai-slop/hallucinated-imports.ts
@@ -268,11 +268,19 @@ const checkJsImport = (
 
 const normalizePyName = (name: string): string => name.toLowerCase().replace(/_/g, "-");
 
+const pyDepSatisfiesImportRoot = (root: string, pyDeps: Set<string>): boolean => {
+	const normalized = normalizePyName(root);
+	for (const dep of pyDeps) {
+		if (dep === normalized || dep.startsWith(`${normalized}-`)) return true;
+	}
+	return false;
+};
+
 const checkPyImport = (spec: string, pyDeps: Set<string>): string | null => {
 	const root = spec.split(".")[0];
 	if (PYTHON_STDLIB.has(root)) return null;
+	if (pyDepSatisfiesImportRoot(root, pyDeps)) return null;
 	const normalized = normalizePyName(root);
-	if (pyDeps.has(normalized)) return null;
 	const distributions = PYTHON_IMPORT_TO_PIP[root] ?? PYTHON_IMPORT_TO_PIP[normalized];
 	if (distributions?.some((dist) => pyDeps.has(normalizePyName(dist)))) return null;
 	return root;

--- a/src/engines/security/audit.ts
+++ b/src/engines/security/audit.ts
@@ -34,10 +34,12 @@ export const runDependencyAudit = async (context: EngineContext): Promise<Diagno
 
 	const promises: Promise<Diagnostic[]>[] = [];
 
-	// npm/pnpm audit
+	// npm/pnpm/bun audit
 	if (context.languages.includes("typescript") || context.languages.includes("javascript")) {
 		if (fs.existsSync(path.join(context.rootDirectory, "pnpm-lock.yaml"))) {
 			promises.push(runPnpmAuditWithFallback(context.rootDirectory, timeout));
+		} else if (hasBunLockfile(context.rootDirectory)) {
+			promises.push(runBunAudit(context.rootDirectory, timeout));
 		} else if (
 			fs.existsSync(path.join(context.rootDirectory, "package-lock.json")) ||
 			fs.existsSync(path.join(context.rootDirectory, "package.json"))
@@ -71,7 +73,10 @@ export const runDependencyAudit = async (context: EngineContext): Promise<Diagno
 	return diagnostics;
 };
 
-type JsAuditSource = "npm audit" | "pnpm audit";
+type JsAuditSource = "npm audit" | "pnpm audit" | "bun audit";
+
+const hasBunLockfile = (rootDir: string): boolean =>
+	fs.existsSync(path.join(rootDir, "bun.lock")) || fs.existsSync(path.join(rootDir, "bun.lockb"));
 
 const errorMessageOf = (error: unknown): string =>
 	error instanceof Error ? error.message : String(error);
@@ -99,6 +104,26 @@ const runNpmAudit = async (rootDir: string, timeout: number): Promise<Diagnostic
 	} catch (error) {
 		return [
 			auditSkippedDiagnostic("npm audit", `Failed to run npm audit: ${errorMessageOf(error)}`),
+		];
+	}
+};
+
+const runBunAudit = async (rootDir: string, timeout: number): Promise<Diagnostic[]> => {
+	try {
+		const result = await runSubprocess("bun", ["audit", "--json"], {
+			cwd: rootDir,
+			timeout,
+		});
+		if (result.stdout) {
+			return parseBunAudit(result.stdout);
+		}
+		if (result.exitCode === 0) return [];
+		return [
+			auditSkippedDiagnostic("bun audit", `Failed to run bun audit: ${result.stderr || "unknown error"}`),
+		];
+	} catch (error) {
+		return [
+			auditSkippedDiagnostic("bun audit", `Failed to run bun audit: ${errorMessageOf(error)}`),
 		];
 	}
 };
@@ -211,8 +236,35 @@ const aggregateToDiagnostic = (agg: VulnAggregate, source: JsAuditSource): Diagn
 		column: 0,
 		category: "Security",
 		fixable: false,
-		detail: source === "npm audit" ? "npm" : "pnpm",
+		detail: source === "npm audit" ? "npm" : source === "pnpm audit" ? "pnpm" : "bun",
 	};
+};
+
+export const parseBunAudit = (output: string): Diagnostic[] => {
+	if (!output.trim()) return [];
+	try {
+		const parsed = JSON.parse(output) as Record<string, unknown>;
+		const bucket = new Map<string, VulnAggregate>();
+
+		for (const [packageName, advisories] of Object.entries(parsed)) {
+			if (!Array.isArray(advisories) || advisories.length === 0) continue;
+			for (const advisory of advisories) {
+				if (!advisory || typeof advisory !== "object") continue;
+				const record = advisory as Record<string, unknown>;
+				const severity = ((record.severity as string) ?? "moderate").toLowerCase();
+				const recommendation =
+					(record.title as string) ??
+					(record.vulnerable_versions as string) ??
+					(record.url as string) ??
+					"";
+				upsertVuln(bucket, packageName, severity, recommendation);
+			}
+		}
+
+		return [...bucket.values()].map((agg) => aggregateToDiagnostic(agg, "bun audit"));
+	} catch {
+		return [];
+	}
 };
 
 const parseLegacyAdvisories = (

--- a/tests/audit-parse.test.ts
+++ b/tests/audit-parse.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { parseJsAudit } from "../src/engines/security/audit.js";
+import { parseBunAudit, parseJsAudit } from "../src/engines/security/audit.js";
 
 describe("parseJsAudit — modern vulnerabilities", () => {
 	it("collapses a transitive chain to the package that carries the advisory", () => {
@@ -92,5 +92,39 @@ describe("parseJsAudit — modern vulnerabilities", () => {
 		expect(diagnostics).toHaveLength(2);
 		expect(diagnostics.map((d) => d.message).join(" ")).toContain("uuid");
 		expect(diagnostics.map((d) => d.message).join(" ")).toContain("lodash");
+	});
+});
+
+describe("parseBunAudit", () => {
+	it("returns no diagnostics for an empty audit result", () => {
+		expect(parseBunAudit("{}")).toEqual([]);
+	});
+
+	it("maps package advisories to vulnerable-dependency diagnostics", () => {
+		const audit = JSON.stringify({
+			lodash: [
+				{
+					id: 1106913,
+					title: "Command Injection in lodash",
+					severity: "high",
+					vulnerable_versions: "<4.17.21",
+				},
+				{
+					id: 1108258,
+					title: "Regular Expression Denial of Service (ReDoS) in lodash",
+					severity: "moderate",
+					vulnerable_versions: ">=4.0.0 <4.17.21",
+				},
+			],
+		});
+
+		const diagnostics = parseBunAudit(audit);
+
+		expect(diagnostics).toHaveLength(1);
+		expect(diagnostics[0].rule).toBe("security/vulnerable-dependency");
+		expect(diagnostics[0].severity).toBe("error");
+		expect(diagnostics[0].message).toContain("lodash");
+		expect(diagnostics[0].message).toContain("high");
+		expect(diagnostics[0].detail).toBe("bun");
 	});
 });

--- a/tests/hallucinated-imports.test.ts
+++ b/tests/hallucinated-imports.test.ts
@@ -554,6 +554,42 @@ from psycopg2 import extras
 		expect(diagnostics).toEqual([]);
 	});
 
+	it("resolves azure namespace imports from azure-* distributions (#235)", async () => {
+		writeFile(
+			"pyproject.toml",
+			`[project]
+name = "repro"
+version = "0.1.0"
+requires-python = ">=3.11"
+dependencies = [
+  "azure-core>=1.41.0",
+  "azure-identity>=1.25.3",
+  "azure-mgmt-containerservice>=40.2.0",
+]
+`,
+		);
+		writeFile(
+			"app.py",
+			`from azure.core.exceptions import AzureError
+from azure.identity import DefaultAzureCredential
+`,
+		);
+
+		const diagnostics = await detectHallucinatedImports(buildContext());
+
+		expect(diagnostics).toEqual([]);
+	});
+
+	it("still flags azure imports when no azure-* distribution is declared", async () => {
+		writeFile("pyproject.toml", `[project]\ndependencies = ["requests>=2.31"]\n`);
+		writeFile("app.py", `from azure.core.exceptions import AzureError\n`);
+
+		const diagnostics = await detectHallucinatedImports(buildContext());
+
+		expect(diagnostics).toHaveLength(1);
+		expect(diagnostics[0].message).toContain("azure");
+	});
+
 	it("does not flag import-shaped text inside docstrings (flask example)", async () => {
 		writeFile("pyproject.toml", `[project]\ndependencies = ["click"]\n`);
 		writeFile(


### PR DESCRIPTION
## Summary

- **#235** — PEP 420 namespace imports: `azure-core` / `azure-identity` now satisfy `import azure.*`
- **#230** — Bun projects: run `bun audit --json` when `bun.lock` / `bun.lockb` is present; doctor shows `bun audit` instead of npm fallback

## Verification

- [x] `npm test` — 1332 tests passing (+4)
- [x] `npm run quality` — score 95, 0 errors

Closes #235
Closes #230