### PR TITLE
chore(dependabot): target develop instead of main

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,10 +2,12 @@ version: 2
 updates:
   - package-ecosystem: npm
     directory: "/"
+    target-branch: "develop"
     schedule:
       interval: weekly
 
   - package-ecosystem: github-actions
     directory: "/"
+    target-branch: "develop"
     schedule:
       interval: weekly


### PR DESCRIPTION
Point Dependabot PRs at `develop` so dependency bumps integrate there first and reach `main` via the normal release. Config must live on the default branch (main) for Dependabot to read it; `target-branch` redirects the PRs.

Existing open Dependabot PRs (#243–#250) are being retargeted to develop separately.