### PR TITLE
fix(masker): don't mask regex literals as comments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Patch release: calibrates the new `ai-slop/hidden-fallback` rule so it stops fla
 ### Fixed
 
 - **`ai-slop/hidden-fallback` false positives.** The rule no longer flags error-message string defaults (`err?.message || "Failed to load"`), empty-string normalizers (`?? ""`), or optional env-var defaults (`process.env.X ?? fallback`). A string fallback counts as a masked value only when it is a status/success token (`"ok"`, `"success"`, …); bare string returns from a catch are still flagged ([#251](https://github.com/scanaislop/aislop/pull/251)).
+- **Comment masker no longer mis-reads regex literals.** A regex literal containing `/*` inside a character class (e.g. `/[/*]/`) was treated as a block comment that masked through end-of-file, producing false complexity / function-too-long diagnostics on regex-heavy code. The JS/TS masker now consumes regex literals before comment detection.
 
 ### Changed
 

--- a/src/utils/source-masker.ts
+++ b/src/utils/source-masker.ts
@@ -77,6 +77,67 @@ const handleQuotesAndComments = (
 	return { handled: false, nextI: i };
 };
 
+const REGEX_PRECEDING_KEYWORDS = new Set([
+	"return",
+	"typeof",
+	"instanceof",
+	"in",
+	"of",
+	"new",
+	"delete",
+	"void",
+	"do",
+	"else",
+	"yield",
+	"await",
+	"case",
+	"throw",
+]);
+
+const regexAllowedAt = (content: string, slashIndex: number): boolean => {
+	let p = slashIndex - 1;
+	while (
+		p >= 0 &&
+		(content[p] === " " || content[p] === "\t" || content[p] === "\n" || content[p] === "\r")
+	) {
+		p--;
+	}
+	if (p < 0) return true;
+	const ch = content[p];
+	if (ch === ")" || ch === "]" || ch === "}" || ch === '"' || ch === "'" || ch === "`") {
+		return false;
+	}
+	if (/[A-Za-z0-9_$]/.test(ch)) {
+		let w = p;
+		while (w >= 0 && /[A-Za-z0-9_$]/.test(content[w])) w--;
+		return REGEX_PRECEDING_KEYWORDS.has(content.slice(w + 1, p + 1));
+	}
+	return true;
+};
+
+const consumeRegex = (content: string, start: number): number => {
+	const len = content.length;
+	let i = start + 1;
+	let inClass = false;
+	while (i < len) {
+		const c = content[i];
+		if (c === "\\") {
+			i += 2;
+			continue;
+		}
+		if (c === "\n") return -1;
+		if (c === "[") inClass = true;
+		else if (c === "]") inClass = false;
+		else if (c === "/" && !inClass) {
+			i++;
+			while (i < len && /[a-z]/i.test(content[i])) i++;
+			return i;
+		}
+		i++;
+	}
+	return -1;
+};
+
 const maskJs = (content: string, maskStrings: boolean): string => {
 	const out = content.split("");
 	const len = content.length;
@@ -110,6 +171,19 @@ const maskJs = (content: string, maskStrings: boolean): string => {
 				}
 				tplStack[tplStack.length - 1]--;
 				i++;
+				continue;
+			}
+		}
+
+		if (
+			c === "/" &&
+			content[i + 1] !== "/" &&
+			content[i + 1] !== "*" &&
+			regexAllowedAt(content, i)
+		) {
+			const regexEnd = consumeRegex(content, i);
+			if (regexEnd !== -1) {
+				i = regexEnd;
 				continue;
 			}
 		}

--- a/tests/source-masker.test.ts
+++ b/tests/source-masker.test.ts
@@ -51,6 +51,26 @@ describe("maskComments", () => {
 		const src = "anything // not a comment here\n";
 		expect(maskComments(src, ".txt")).toBe(src);
 	});
+
+	it("does not treat /* inside a regex character class as a block comment", () => {
+		const src = [
+			"function f() {",
+			"  const re = /[/*]/;",
+			"  return re.test('x');",
+			"}",
+			"const after = 1;",
+			"",
+		].join("\n");
+		const out = maskComments(src, ".ts");
+		expect(out).toContain("const after = 1;");
+		expect(out).toContain("re.test");
+	});
+
+	it("still masks a line comment that follows a division", () => {
+		const out = maskComments("const r = a / b // secret\n", ".ts");
+		expect(out).toContain("a / b");
+		expect(out).not.toContain("secret");
+	});
 });
 
 describe("maskStringsAndComments still masks string bodies", () => {


### PR DESCRIPTION
## Problem (Codex P2)

In JS/TS, a regex literal with `/*` inside a character class — e.g. `/[/*]/` — made `maskComments` treat the `/*` as a block-comment start and mask through end-of-file. Since function-end detection runs on the masked lines, the enclosing function was reported as extending to EOF → **false `code-quality/complexity` / function-too-long diagnostics** on valid regex-heavy code.

## Fix

`maskJs` now consumes **regex literals** (handling character classes and escapes) before the `//` / `/*` comment checks, so a `/*` inside a regex is never seen as a comment. Regex-vs-division is decided by a conservative prev-token heuristic (`regexAllowedAt`): a `/` is only treated as a regex after operators / `(` / `,` / `=` / `[` / `:` / regex-preceding keywords (`return`, `typeof`, …) — never after a value (identifier, `)`, `]`, `}`, string), so real division can't be misread and swallow a following comment. Unterminated / newline-spanning slashes fall back to division.

## Tests
- `/[/*]/` no longer masks to EOF (function body + trailing code intact).
- A line comment after a division (`a / b // secret`) is still masked (guards against misclassifying division as regex).
- Full suite: 1365 passing; `aislop scan` 100/100.

Lands on develop; the open **Release: v0.13.1** PR (#255) picks it up.