### PR TITLE
docs(agents): add cross-platform script + writing conventions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -23,6 +23,35 @@ pnpm scan              # Build + run aislop on itself
 node dist/cli.js scan . # Run after building manually
 ```
 
+## Cross-platform scripts
+
+Contributors and CI run on Linux, macOS, and Windows. Keep `package.json`
+scripts portable:
+
+- **No Unix-only shell in scripts.** `rm -rf`, `cp`, `mv`, etc. fail under
+  cmd.exe on Windows. tsdown already cleans its output directory before each
+  build, so an explicit `rm -rf dist` is redundant; the `build` script is just
+  `tsdown`.
+- **No `VAR=value cmd` prefixes.** cmd.exe cannot parse a leading env-var
+  assignment, so `NODE_ENV=production tsdown` errors with
+  `'NODE_ENV' is not recognized`. If a script genuinely needs an env var set
+  cross-platform, add the `cross-env` dev dependency and use
+  `cross-env VAR=value cmd`.
+- **A green Linux CI run is not a Windows guarantee.** A handful of
+  path/permission tests (home-dir resolution, `0600` permission bits,
+  repo-relative path conversion) are environment-specific and may fail locally
+  on Windows while passing in CI. Emit forward-slash paths in diagnostics so
+  `/`-anchored classifiers match on every OS.
+
+## Writing conventions
+
+- **No hard-coded machine-specific paths** in shipped code (e.g.
+  `C:\Users\...`, `/home/...`). Derive from `os.homedir()`, env vars, or
+  arguments so it works across machines and CI.
+- **Avoid em-dashes** (U+2014) in committed prose and string literals; a stray
+  em-dash can force a cp1252 re-encode on some Windows toolchains. Use ASCII
+  (` - `, `:`, or parentheses).
+
 ## Key architecture decisions
 
 - **TypeScript strict mode**, ES2022 target, bundler module resolution


### PR DESCRIPTION
### Motivation

Following the cross-platform build-script fix (#231), the portability
constraints that prevented it were not written down anywhere, so the next
contributor on a non-Windows machine could reintroduce them. This documents the
rules so they are discoverable up front.

### Description

Add two short sections to `AGENTS.md`:

- **Cross-platform scripts** - no Unix-only shell or `VAR=value` prefixes in
  `package.json` scripts (cmd.exe cannot run them), and a note that a green Linux
  CI run is not a Windows guarantee (emit forward-slash paths so `/`-anchored
  classifiers match on every OS).
- **Writing conventions** - no hard-coded machine-specific paths in shipped
  code, and avoid em-dashes in committed prose/string literals (a stray U+2014
  can force a cp1252 re-encode on some Windows toolchains).

### Type of change

- [x] Documentation

### Checklist

- [x] Docs-only change; `pnpm typecheck` / `pnpm build` / tests unaffected
- [x] CI green on Node 22 + 24
