### PR TITLE
fix(ai-slop): remove unused type exports

### DIFF
--- a/src/engines/ai-slop/hallucinated-imports-manifest.ts
+++ b/src/engines/ai-slop/hallucinated-imports-manifest.ts
@@ -3,13 +3,13 @@ import path from "node:path";
 import { collectWorkspaceDirs } from "./js-workspaces.js";
 import { collectPythonDeps, type PythonDependencyScope } from "./python-manifest.js";
 
-export interface JsDependencyScope {
+interface JsDependencyScope {
 	directory: string;
 	jsDeps: Set<string>;
 	packageName?: string;
 }
 
-export interface PackageManifest {
+interface PackageManifest {
 	jsDeps: Set<string>;
 	jsScopes: JsDependencyScope[];
 	pyDeps: Set<string>;


### PR DESCRIPTION
Removes two internal-only exports so the full develop scan returns 100/100. Validated with pnpm quality: 1,365 tests passing.