### PR TITLE
fix(hallucinated-import): close three Python import-scope gaps

### DIFF
--- a/src/engines/ai-slop/python-data.ts
+++ b/src/engines/ai-slop/python-data.ts
@@ -194,6 +194,7 @@ export const PYTHON_IMPORT_TO_PIP: Record<string, string[]> = {
 	docx: ["python-docx"],
 	pptx: ["python-pptx"],
 	git: ["gitpython"],
+	github: ["pygithub"],
 	socks: ["pysocks"],
 	psycopg2: ["psycopg2-binary", "psycopg2"],
 	redis: ["redis"],

--- a/src/engines/ai-slop/python-manifest.ts
+++ b/src/engines/ai-slop/python-manifest.ts
@@ -88,7 +88,11 @@ const collectNestedScopes = (rootDir: string): PythonDependencyScope[] => {
 
 		for (const entry of entries) {
 			if (!entry.isDirectory()) continue;
-			if (entry.name.startsWith(".") || SKIP_MANIFEST_DIRS.has(entry.name)) continue;
+			// Dot-directories are not blanket-skipped here: CI tooling commonly lives
+			// under .ci, .github, .circleci, etc. with its own requirements.txt, and
+			// files under it need that scope. Known noise directories (.git, .venv,
+			// caches, ...) are excluded explicitly via SKIP_MANIFEST_DIRS instead.
+			if (SKIP_MANIFEST_DIRS.has(entry.name)) continue;
 			walk(path.join(dir, entry.name), depth + 1);
 		}
 	};
@@ -186,6 +190,16 @@ const findUvWorkspace = (startDir: string): UvWorkspaceInfo | null => {
 	return null;
 };
 
+// A scope rooted under a dot-directory (.ci, .github, etc.) is walked so
+// files within that subtree get its manifest, but its deps must not leak
+// into the flat aggregate below: pythonDepsForFile falls back to that
+// aggregate for any file whose own scope comes up empty, and a dot-directory
+// commonly holds CI-only tooling deps that do not apply outside it.
+const isUnderDotDirectory = (rootDir: string, scopeDir: string): boolean => {
+	const relative = path.relative(rootDir, scopeDir);
+	return relative.split(path.sep).some((segment) => segment.startsWith("."));
+};
+
 export const collectPythonDeps = (
 	rootDir: string,
 ): {
@@ -215,6 +229,7 @@ export const collectPythonDeps = (
 	}
 	const pyDeps = new Set<string>();
 	for (const scope of scopes) {
+		if (isUnderDotDirectory(rootDir, scope.directory)) continue;
 		for (const dep of scope.pyDeps) pyDeps.add(dep);
 	}
 	return {

--- a/tests/hallucinated-imports.test.ts
+++ b/tests/hallucinated-imports.test.ts
@@ -1032,6 +1032,112 @@ import cv2
 
 		expect(diagnostics).toEqual([]);
 	});
+
+	it("finds a nested requirements.txt scope under a dot-directory (e.g. .ci)", async () => {
+		// Regression: nested manifest discovery used to blanket-skip every
+		// dot-prefixed directory, so CI tooling under .ci/.github/etc. with its
+		// own requirements.txt never got a dependency scope (llvm-project's
+		// .ci/requirements.txt is the real-world case that surfaced this).
+		writeFile("pyproject.toml", `[project]\nname = "root-demo"\n`);
+		writeFile(".ci/requirements.txt", "junitparser==3.2.0\n");
+		writeFile(".ci/generate_report.py", `import junitparser\n`);
+
+		const diagnostics = await detectHallucinatedImports(buildContext());
+
+		expect(diagnostics).toEqual([]);
+	});
+
+	it("still skips known noise directories when discovering nested Python scopes", async () => {
+		writeFile("pyproject.toml", `[project]\nname = "root-demo"\n`);
+		writeFile(".venv/lib/requirements.txt", "shouldnotcount==1.0\n");
+		writeFile("src/main.py", `import shouldnotcount\n`);
+
+		const diagnostics = await detectHallucinatedImports(buildContext());
+
+		expect(diagnostics).toHaveLength(1);
+		expect(diagnostics[0].message).toContain("shouldnotcount");
+	});
+
+	it("resolves the github import name to the PyGithub distribution", async () => {
+		writeFile("requirements.txt", "PyGithub==2.8.1\n");
+		writeFile(
+			"src/bot.py",
+			`import github
+from github import Github
+`,
+		);
+
+		const diagnostics = await detectHallucinatedImports(buildContext());
+
+		expect(diagnostics).toEqual([]);
+	});
+
+	it("does not flag an import of a sibling script-style module in the same directory", async () => {
+		// Regression: plain script-style Python (no package/__init__.py) commonly
+		// imports a sibling file by its bare module name. This never needs a
+		// dependency manifest entry, but was previously always flagged unless
+		// the sibling happened to be a package under a scope's package roots.
+		writeFile("requirements.txt", "requests==2.31.0\n");
+		writeFile(".ci/report_lib.py", "def build():\n    return 1\n");
+		writeFile(
+			".ci/report_main.py",
+			`import requests
+import report_lib
+`,
+		);
+
+		const diagnostics = await detectHallucinatedImports(buildContext());
+
+		expect(diagnostics).toEqual([]);
+	});
+
+	it("does not flag a sibling package import (directory with __init__.py)", async () => {
+		writeFile("requirements.txt", "requests==2.31.0\n");
+		writeFile("tools/helpers/__init__.py", "");
+		writeFile(
+			"tools/main.py",
+			`import requests
+import helpers
+`,
+		);
+
+		const diagnostics = await detectHallucinatedImports(buildContext());
+
+		expect(diagnostics).toEqual([]);
+	});
+
+	it("still flags an import with no matching sibling file, package, or manifest entry", async () => {
+		writeFile("requirements.txt", "requests==2.31.0\n");
+		writeFile(".ci/report_lib.py", "def build():\n    return 1\n");
+		writeFile(
+			".ci/report_main.py",
+			`import requests
+import made_up_lib
+`,
+		);
+
+		const diagnostics = await detectHallucinatedImports(buildContext());
+
+		expect(diagnostics).toHaveLength(1);
+		expect(diagnostics[0].message).toContain("made_up_lib");
+	});
+
+	it("does not leak a dot-directory manifest's deps into a root file with an empty root manifest", async () => {
+		// Regression: when the scan root has a valid but dependency-free manifest
+		// (an empty requirements.txt here), pythonDepsForFile fell back to the
+		// aggregate manifest.pyDeps once its own scope came up empty. Now that
+		// dot-directories are walked for nested scopes, that aggregate could
+		// include .ci-only dependencies, wrongly clearing a root-level file that
+		// imports a package declared only under .ci/requirements.txt.
+		writeFile("requirements.txt", "# no top-level runtime deps yet\n");
+		writeFile(".ci/requirements.txt", "junitparser==3.2.0\n");
+		writeFile("src/app.py", "import junitparser\n");
+
+		const diagnostics = await detectHallucinatedImports(buildContext());
+
+		expect(diagnostics).toHaveLength(1);
+		expect(diagnostics[0].message).toContain("junitparser");
+	});
 });
 
 describe("detectHallucinatedImports: uv workspace", () => {


### PR DESCRIPTION
Closes three import-scope gaps in the Python `hallucinated-import` detector to eliminate false positives found while scanning large real-world Python repos:

### 1. Nested manifests in dot-directories
`collectNestedScopes` blanket-skipped every dot-prefixed directory, so `requirements.txt` files under `.ci/`, `.github/`, `.circleci/` etc. were never picked up as dependency scopes. Files under those directories would get flagged for imports that were perfectly declared in their local manifest. Fix: stop skipping dot-dirs in the walk; rely on the explicit `SKIP_MANIFEST_DIRS` set (`.git`, `.venv`, etc.) instead.

### 2. PyGithub import mapping
`import github` was not mapped to the `PyGithub` pip distribution. One-line addition to `PYTHON_IMPORT_TO_PIP`.

### 3. Local sibling script imports
Plain script-style Python (`import foo` where `foo.py` sits next to the importing file) was always flagged unless the sibling happened to be under a manifest scope's package roots. Fix: check for `foo.py` or `foo/__init__.py` in the importing file's directory before reporting.

### Changes
- `hallucinated-imports.ts`: add `hasSiblingPythonModule` check, pass `fileDir` through
- `python-data.ts`: add `github -> PyGithub` mapping
- `python-manifest.ts`: stop blanket-skipping dot-directories in nested scope walk
- `hallucinated-imports.test.ts`: 7 new test cases covering all three gaps

4 files changed, +107/-3.
