### PR TITLE
fix(scanner): harden declaration and dot-directory exclusions

### DIFF
--- a/src/utils/source-file-policy.ts
+++ b/src/utils/source-file-policy.ts
@@ -110,9 +110,9 @@ export const WALK_PRUNE_DIRECTORIES = new Set([
 const TEST_FILE_PATTERNS = [
 	/(?:^|\/).*\.test\.[^/]+$/i,
 	/(?:^|\/).*\.spec\.[^/]+$/i,
-	/(?:^|\/).*\.stories?\.[^/]+$/i,
-	/(?:^|\/)test_[^/]+\.(?:py|rb|php|js|jsx|ts|tsx|java)$/i,
-	/(?:^|\/)[^/]+_test\.(?:py|go|rb|php|js|jsx|ts|tsx|java)$/i,
+	/(?:^|\/).*\.stor(?:y|ies)\.[^/]+$/i,
+	/(?:^|\/)test_[^/]+\.(?:py|rb|php|js|jsx|d\.ts|ts|tsx|java)$/i,
+	/(?:^|\/)[^/]+_test\.(?:py|go|rb|php|js|jsx|d\.ts|ts|tsx|java)$/i,
 ];
 
 export const toProjectPath = (rootDirectory: string, filePath: string): string => {
@@ -142,9 +142,12 @@ export const hasAllowedSourceExtension = (
 ): boolean =>
 	SOURCE_EXTENSIONS.has(path.extname(filePath)) || extraExtensions.has(path.extname(filePath));
 
-const isExcludedPath = (filePath: string): boolean => {
+export const isInExcludedDirectory = (
+	filePath: string,
+	excludedDirectories: readonly string[],
+): boolean => {
 	const normalized = filePath.toLowerCase();
-	return EXCLUDED_SOURCE_DIRECTORIES.some(
+	return excludedDirectories.some(
 		(directory) =>
 			normalized === directory ||
 			normalized.startsWith(`${directory}/`) ||
@@ -153,7 +156,8 @@ const isExcludedPath = (filePath: string): boolean => {
 };
 
 export const isExcludedFromScan = (relativePath: string): boolean =>
-	isExcludedPath(relativePath) || isGeneratedArtifactFile(relativePath);
+	isInExcludedDirectory(relativePath, EXCLUDED_SOURCE_DIRECTORIES) ||
+	isGeneratedArtifactFile(relativePath);
 
 export const isTestFile = (filePath: string): boolean =>
 	TEST_FILE_PATTERNS.some((pattern) => pattern.test(filePath));

--- a/src/utils/source-file-selection.ts
+++ b/src/utils/source-file-selection.ts
@@ -6,6 +6,7 @@ import { enumerateProjectFiles, enumerateProjectFilesFromDisk } from "./project-
 import {
 	EXCLUDED_SOURCE_DIRECTORIES,
 	hasAllowedSourceExtension,
+	isInExcludedDirectory,
 	isSafeRegularProjectFile,
 	isTestFile,
 	isWithinProject,
@@ -13,6 +14,11 @@ import {
 	toProjectPath,
 	WALK_PRUNE_DIRECTORIES,
 } from "./source-file-policy.js";
+
+const GENERATED_DECLARATION_DIRECTORIES = new Set(["generated", "__generated__", "auto-generated"]);
+const DECLARATION_EXCLUDED_DIRECTORIES = EXCLUDED_SOURCE_DIRECTORIES.filter(
+	(directory) => !GENERATED_DECLARATION_DIRECTORIES.has(directory),
+);
 
 export const listProjectFiles = (rootDirectory: string): string[] =>
 	enumerateProjectFiles(rootDirectory, WALK_PRUNE_DIRECTORIES);
@@ -22,12 +28,13 @@ export const listProjectFilesFromDisk = (rootDirectory: string): string[] =>
 
 const normalizeExcludePatterns = (patterns: string[]): string[] =>
 	patterns.flatMap((pattern) => {
-		const normalized = pattern.trim();
-		if (normalized.startsWith(".")) return [`**/*${normalized}`];
-		if (!normalized.includes("*") && !normalized.includes(".")) {
-			return [`${normalized}/**`];
+		const normalized = pattern.trim().replace(/^\.\//, "").replace(/\/+$/, "");
+		if (normalized.length === 0) return [];
+		if (micromatch.scan(normalized).isGlob) return [normalized];
+		if (normalized.startsWith(".") && !normalized.includes("/")) {
+			return [`**/*${normalized}`, `**/${normalized}/**`];
 		}
-		return [normalized];
+		return [normalized, `${normalized}/**`];
 	});
 
 const normalizeIncludePatterns = (patterns: string[]): string[] =>
@@ -87,16 +94,9 @@ const filterFiles = (
 
 	return normalizedFiles
 		.filter(({ absolutePath, relativePath }) => {
-			const normalizedPath = relativePath.toLowerCase();
-			const excludedDirectory = excludedDirectories.some(
-				(directory) =>
-					normalizedPath === directory ||
-					normalizedPath.startsWith(`${directory}/`) ||
-					normalizedPath.includes(`/${directory}/`),
-			);
 			if (
 				!isSafeRegularProjectFile(rootDirectory, absolutePath) ||
-				excludedDirectory ||
+				isInExcludedDirectory(relativePath, excludedDirectories) ||
 				isTestFile(relativePath) !== options.testFiles ||
 				isGeneratedArtifactFile(relativePath) ||
 				ignoredPaths.has(relativePath)
@@ -184,6 +184,12 @@ export const filterProjectDeclarationFiles = (
 	return filterExplicitFiles(rootDirectory, files).filter((filePath) => {
 		if (!filePath.endsWith(".d.ts")) return false;
 		const relativePath = toProjectPath(rootDirectory, filePath);
+		if (
+			isTestFile(relativePath) ||
+			isInExcludedDirectory(relativePath, DECLARATION_EXCLUDED_DIRECTORIES)
+		) {
+			return false;
+		}
 		if (
 			includePatterns.length > 0 &&
 			!micromatch.isMatch(relativePath, includePatterns, { dot: true })

--- a/tests/hallucinated-import-declarations.test.ts
+++ b/tests/hallucinated-import-declarations.test.ts
@@ -84,4 +84,38 @@ describe("ambient declaration module classification", () => {
 
 		expect(diags).toEqual([]);
 	});
+
+	it("does not trust ambient declarations from excluded paths", async () => {
+		writeFile("package.json", JSON.stringify({ name: "app", dependencies: {} }));
+		writeFile("tests/ambient.d.ts", 'declare module "ghost-module" {}\n');
+		writeFile("fixtures/ambient.d.ts", 'declare module "fixture-ghost-module" {}\n');
+		writeFile("src/ambient_test.d.ts", 'declare module "suffix-ghost-module" {}\n');
+		writeFile("src/test_ambient.d.ts", 'declare module "prefix-ghost-module" {}\n');
+		writeFile("src/ambient.story.d.ts", 'declare module "story-ghost-module" {}\n');
+		writeFile(
+			"src/app.ts",
+			[
+				'import value from "ghost-module";',
+				'import fixture from "fixture-ghost-module";',
+				'import suffix from "suffix-ghost-module";',
+				'import prefix from "prefix-ghost-module";',
+				'import story from "story-ghost-module";',
+				"value();",
+				"fixture();",
+				"suffix();",
+				"prefix();",
+				"story();",
+			].join("\n"),
+		);
+
+		const diags = await detectHallucinatedImports(buildContext());
+
+		expect(diags.map((diag) => diag.message)).toEqual([
+			expect.stringContaining("ghost-module"),
+			expect.stringContaining("fixture-ghost-module"),
+			expect.stringContaining("suffix-ghost-module"),
+			expect.stringContaining("prefix-ghost-module"),
+			expect.stringContaining("story-ghost-module"),
+		]);
+	});
 });

--- a/tests/source-file-excludes.test.ts
+++ b/tests/source-file-excludes.test.ts
@@ -1,0 +1,66 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { filterEnumeratedProjectFiles } from "../src/utils/source-files.js";
+
+describe("exclude pattern normalization", () => {
+	let tmpDir: string;
+
+	beforeEach(() => {
+		tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "aislop-source-excludes-"));
+	});
+
+	afterEach(() => {
+		fs.rmSync(tmpDir, { recursive: true, force: true });
+	});
+
+	const createFile = (relativePath: string): void => {
+		const absolutePath = path.join(tmpDir, relativePath);
+		fs.mkdirSync(path.dirname(absolutePath), { recursive: true });
+		fs.writeFileSync(absolutePath, "export const value = true;\n", "utf-8");
+	};
+
+	it.each([
+		[".idea", ["src/app.ts"]],
+		[".idea/", ["src/app.ts"]],
+		["./.idea", ["src/app.ts"]],
+		["apps/web/.idea", [".idea/project.ts", "src/app.ts"]],
+	])("excludes dot-directory descendants for literal %s", (exclude, expectedFiles) => {
+		createFile(".idea/project.ts");
+		createFile("apps/web/.idea/workspace.ts");
+		createFile("src/app.ts");
+
+		const filtered = filterEnumeratedProjectFiles(
+			tmpDir,
+			[".idea/project.ts", "apps/web/.idea/workspace.ts", "src/app.ts"],
+			[],
+			[exclude],
+		);
+
+		expect(filtered.sort()).toEqual(expectedFiles.map((file) => path.join(tmpDir, file)).sort());
+	});
+
+	it("preserves root and nested dotfile exclusion", () => {
+		createFile(".hidden.ts");
+		createFile("src/.hidden.ts");
+		createFile("src/app.ts");
+
+		const filtered = filterEnumeratedProjectFiles(
+			tmpDir,
+			[".hidden.ts", "src/.hidden.ts", "src/app.ts"],
+			[],
+			[".hidden.ts"],
+		);
+
+		expect(filtered).toEqual([path.join(tmpDir, "src/app.ts")]);
+	});
+
+	it.each(["", "   ", "./", "/", "///"])("ignores empty or root-like exclusion %j", (exclude) => {
+		createFile("src/app.ts");
+
+		const filtered = filterEnumeratedProjectFiles(tmpDir, ["src/app.ts"], [], [exclude]);
+
+		expect(filtered).toEqual([path.join(tmpDir, "src/app.ts")]);
+	});
+});


### PR DESCRIPTION
## What does this PR do?

Addresses the actionable scanner feedback raised on #294 without merging that release PR:

- prevents declarations in tests, fixtures, vendor, and other excluded source directories from becoming project-wide import evidence;
- preserves generated ambient declarations as intentional compiler evidence;
- makes literal dot-directory excludes such as `.idea`, `.idea/`, `./.idea`, and `apps/web/.idea` apply to descendants;
- ignores empty and root-like exclude values instead of passing an invalid empty pattern to Micromatch;
- expands declaration test-name coverage for `_test.d.ts`, `test_*.d.ts`, `.story.d.ts`, and `.stories.d.ts`.

The separate suggestion that `**/*.env` cannot match a root `.env` is not reproducible with the scanner's existing Micromatch `{ dot: true }` option. That behavior is preserved and covered with root and nested dotfile regression tests.

## Type of change

- [x] Bug fix (fixes an issue without changing behavior)
- [ ] New rule (adds a new detection rule)
- [ ] New feature (adds functionality)
- [ ] Refactor (no behavior change)
- [ ] Documentation
- [ ] CI / tooling

## Checklist

- [x] `pnpm typecheck` passes
- [x] `pnpm test` passes (1,549 tests)
- [x] `pnpm build && node dist/cli.js scan .` scores Healthy (100/100, 427 files, zero diagnostics)
- [x] New behavior has positive and negative regression cases
- [x] All local Aislop scans ran with telemetry, history, and update checks disabled
- [x] No new rules were added

## Related issues

Follow-up to review discussions on #294. This PR targets `develop`; it does not merge or replace the release PR itself.
