### PR TITLE
fix(release): prepare npm v12 and trusted publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,14 +5,15 @@ on:
     types: [published]
 
 permissions:
-  contents: write
-  packages: write
-  id-token: write
+  contents: read
 
 jobs:
   publish-npm:
     name: Publish to npm
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
 
     steps:
       - uses: actions/checkout@v7
@@ -23,8 +24,8 @@ jobs:
 
       - uses: actions/setup-node@v7
         with:
-          node-version: 22
-          cache: pnpm
+          node-version: 24
+          package-manager-cache: false
           registry-url: https://registry.npmjs.org
 
       - name: Install dependencies
@@ -41,16 +42,22 @@ jobs:
 
       - name: Self-scan
         run: node dist/cli.js scan . --json
+        env:
+          AISLOP_NO_HISTORY: "1"
+          AISLOP_NO_TELEMETRY: "1"
+          AISLOP_NO_UPDATE_NOTIFIER: "1"
+          DO_NOT_TRACK: "1"
 
       - name: Publish to npm
         run: npm publish --access public
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
   publish-gpr:
     name: Publish to GitHub Packages
     runs-on: ubuntu-latest
     needs: publish-npm
+    permissions:
+      contents: read
+      packages: write
 
     steps:
       - uses: actions/checkout@v7
@@ -61,8 +68,8 @@ jobs:
 
       - uses: actions/setup-node@v7
         with:
-          node-version: 22
-          cache: pnpm
+          node-version: 24
+          package-manager-cache: false
           registry-url: https://npm.pkg.github.com
           scope: '@scanaislop'
 
@@ -85,6 +92,8 @@ jobs:
     runs-on: ubuntu-latest
     needs: publish-npm
     if: ${{ !github.event.release.prerelease }}
+    permissions:
+      contents: write
 
     steps:
       - uses: actions/checkout@v7

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,10 +25,12 @@ Minor release: expands project discovery and Python workspace awareness, makes d
 
 - **Dependency and CI updates.** Refreshed Biome, Expo Doctor, oxlint, Vitest, YAML, Zod, adm-zip, and the pnpm setup action while preserving the Node 20 runtime floor.
 - **Agent guidance.** Claude Code and Gemini CLI now load the canonical contributor instructions through lightweight pointer files ([#272](https://github.com/scanaislop/aislop/pull/272)).
+- **npm v12-safe installation.** Package installation no longer relies on a dependency `postinstall` script. The core scanner installs without lifecycle execution; `aislop-tools` explicitly installs the optional Ruff and golangci-lint binaries and fails visibly if that setup cannot complete.
+- **Tokenless npm publishing.** The release job now uses npm trusted publishing with OIDC, Node 24, disabled release caches, and job-scoped least-privilege permissions instead of a long-lived `NPM_TOKEN`.
 
 ### Tests
 
-Full suite at 1,471 passing, including regression coverage for provider failures, Windows paths, source-only language detection, ignored TypeScript projects, complexity masking, and uv workspace boundaries.
+Full suite at 1,553 passing, including regression coverage for provider failures, Windows paths, source-only language detection, ignored TypeScript projects, complexity masking, uv workspace boundaries, npm v12-safe packaging, and the OIDC release contract.
 
 ## 0.13.1 (2026-06-29)
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -249,7 +249,14 @@ Language support involves several layers:
 
 ## Releases
 
-Releases are automated. When a maintainer creates a GitHub Release (or pushes a `v*` tag), CI builds and publishes to npm using OIDC trusted publishing -- no long-lived tokens required. See `.github/workflows/release.yml`.
+Releases are automated. Publishing a GitHub Release runs `.github/workflows/release.yml`, which publishes to npm through OIDC trusted publishing without a long-lived npm token.
+
+The npm package's trusted publisher must match these values exactly:
+
+- Organization: `scanaislop`
+- Repository: `aislop`
+- Workflow filename: `release.yml`
+- Allowed action: `npm publish`
 
 Version bumps follow [semver](https://semver.org/):
 

--- a/README.md
+++ b/README.md
@@ -80,6 +80,8 @@ npm install -g aislop
 
 Also available as [`@scanaislop/aislop`](docs/installation.md) on GitHub Packages.
 
+Package installation does not run dependency lifecycle scripts. After installing, run `aislop-tools` once if you want bundled Ruff and golangci-lint coverage; the core scanner works without it.
+
 **Homebrew** (macOS / Linux)
 
 ```bash
@@ -96,7 +98,7 @@ pipx install aislop
 
 `pipx` keeps `aislop` in its own isolated environment. Needs Node.js on `PATH`. Details: [PyPI package](https://pypi.org/project/aislop/).
 
-Full reference for every channel, bundled tooling, and external tools: [docs/installation.md](docs/installation.md).
+Full reference for every channel, optional bundled tooling, and external tools: [docs/installation.md](docs/installation.md).
 
 ---
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -4,7 +4,7 @@ The same CLI is published to npm, Homebrew, and PyPI. Pick whichever fits your s
 
 | Channel | Command | Notes |
 |---|---|---|
-| npm / npx | `npx aislop@latest scan` | No install; bundles its own tooling |
+| npm / npx | `npx aislop@latest scan` | No install; optional native tools are described below |
 | Homebrew | `brew install scanaislop/tap/aislop` | macOS / Linux; pulls Node as a dependency |
 | Python / pipx | `pipx install aislop` | Isolated env; needs Node on `PATH` |
 
@@ -71,13 +71,21 @@ pipx install aislop
 
 ## Bundled tooling
 
-`aislop` ships with Node-based tooling (oxlint, biome, knip) as package dependencies. On install it also downloads bundled binaries for **ruff** and **golangci-lint**.
+`aislop` ships with its Node-based tooling (oxlint, biome, knip) as package dependencies. Installing the package does not run dependency lifecycle scripts, so the core scanner works with npm v12's secure install defaults.
 
-To skip binary downloads:
+For bundled **ruff** and **golangci-lint** coverage, run the explicit tool installer once after installing `aislop`:
 
 ```bash
-AISLOP_SKIP_TOOL_DOWNLOAD=1 npm install
+aislop-tools
 ```
+
+For a one-off npx installation:
+
+```bash
+npx --yes --package=aislop@latest aislop-tools
+```
+
+The command exits non-zero if a supported binary cannot be installed. Run `aislop doctor` afterwards to verify the tools available to each engine.
 
 ## External tools
 

--- a/package.json
+++ b/package.json
@@ -4,8 +4,9 @@
   "description": "Catch the slop AI coding agents leave in your code: narrative comments, swallowed exceptions, as-any casts, dead code, oversized functions. 50+ rules across 8 language targets (TypeScript, JavaScript, Expo / React Native, Python, Go, Rust, Ruby, PHP). Sub-second, deterministic, no LLM at runtime. MIT-licensed.",
   "type": "module",
   "bin": {
-    "aislop": "./dist/cli.js",
-    "aislop-mcp": "./dist/mcp.js"
+    "aislop": "dist/cli.js",
+    "aislop-mcp": "dist/mcp.js",
+    "aislop-tools": "scripts/install-tools.mjs"
   },
   "files": [
     "dist",
@@ -40,7 +41,6 @@
   "scripts": {
     "dev": "tsdown --watch",
     "build": "tsdown",
-    "postinstall": "node scripts/postinstall-tools.mjs",
     "typecheck": "tsc --noEmit",
     "gen:schema": "node --experimental-strip-types scripts/gen-config-schema.mjs",
     "test": "pnpm build && vitest run",

--- a/scripts/install-tools.mjs
+++ b/scripts/install-tools.mjs
@@ -218,11 +218,6 @@ const installTool = async (tool) => {
 };
 
 const main = async () => {
-	if (process.env.AISLOP_SKIP_TOOL_DOWNLOAD === "1") {
-		info("Skipping bundled tool download (AISLOP_SKIP_TOOL_DOWNLOAD=1).");
-		return;
-	}
-
 	const failures = [];
 	for (const tool of TOOL_DEFINITIONS) {
 		try {
@@ -245,6 +240,8 @@ const main = async () => {
 		warn(
 			"aislop will still run, but coverage for those tools may be reduced until installation succeeds.",
 		);
+		process.exitCode = 1;
+		return;
 	}
 
 	printNextSteps();
@@ -260,6 +257,7 @@ const printNextSteps = () => {
 
 main().catch((error) => {
 	warn(
-		`postinstall failed: ${error instanceof Error ? error.message : String(error)}`,
+		`tool installation failed: ${error instanceof Error ? error.message : String(error)}`,
 	);
+	process.exitCode = 1;
 });

--- a/tests/package-release-security.test.ts
+++ b/tests/package-release-security.test.ts
@@ -1,0 +1,69 @@
+import fs from "node:fs";
+import { describe, expect, it } from "vitest";
+import { parse as parseYaml } from "yaml";
+import { z } from "zod/v4";
+
+const PackageManifestSchema = z.object({
+	bin: z.record(z.string(), z.string()),
+	scripts: z.record(z.string(), z.string()),
+});
+
+const WorkflowStepSchema = z.object({
+	env: z.record(z.string(), z.string()).optional(),
+	name: z.string().optional(),
+	run: z.string().optional(),
+	uses: z.string().optional(),
+	with: z.record(z.string(), z.unknown()).optional(),
+});
+
+const WorkflowJobSchema = z.object({
+	permissions: z.record(z.string(), z.string()),
+	steps: z.array(WorkflowStepSchema),
+});
+
+const ReleaseWorkflowSchema = z.object({
+	jobs: z.object({
+		"move-major-tag": WorkflowJobSchema,
+		"publish-gpr": WorkflowJobSchema,
+		"publish-npm": WorkflowJobSchema,
+	}),
+	permissions: z.record(z.string(), z.string()),
+});
+
+describe("package release security", () => {
+	it("keeps optional tool downloads out of dependency lifecycle scripts", () => {
+		const manifest = PackageManifestSchema.parse(
+			JSON.parse(fs.readFileSync("package.json", "utf8")),
+		);
+
+		expect(manifest.scripts.postinstall).toBeUndefined();
+		expect(manifest.bin).toEqual({
+			aislop: "dist/cli.js",
+			"aislop-mcp": "dist/mcp.js",
+			"aislop-tools": "scripts/install-tools.mjs",
+		});
+	});
+
+	it("publishes to npm through a least-privilege OIDC job", () => {
+		const workflowSource = fs.readFileSync(".github/workflows/release.yml", "utf8");
+		const workflow = ReleaseWorkflowSchema.parse(parseYaml(workflowSource));
+		const npmJob = workflow.jobs["publish-npm"];
+		const setupNode = npmJob.steps.find((step) => step.uses?.startsWith("actions/setup-node@"));
+		const publish = npmJob.steps.find((step) => step.name === "Publish to npm");
+
+		expect(workflow.permissions).toEqual({ contents: "read" });
+		expect(npmJob.permissions).toEqual({ contents: "read", "id-token": "write" });
+		expect(setupNode?.with).toMatchObject({
+			"node-version": 24,
+			"package-manager-cache": false,
+		});
+		expect(publish?.run).toBe("npm publish --access public");
+		expect(publish?.env).toBeUndefined();
+		expect(workflowSource).not.toContain("secrets.NPM_TOKEN");
+		expect(workflow.jobs["publish-gpr"].permissions).toEqual({
+			contents: "read",
+			packages: "write",
+		});
+		expect(workflow.jobs["move-major-tag"].permissions).toEqual({ contents: "write" });
+	});
+});


### PR DESCRIPTION
## Summary

- remove dependency lifecycle downloads so npm v12 installs the core scanner without install-time scripts
- expose `aislop-tools` as an explicit, fail-visible installer for optional Ruff and golangci-lint binaries
- migrate npm publication to trusted publishing with Node 24, OIDC, disabled setup cache, and job-scoped permissions
- document the npm trusted-publisher identity and protect the release contract with regression tests

## Validation

- `pnpm quality` — 167 test files / 1,553 tests passed
- telemetry-free self-scan — 100/100, 428 supported files, 0 findings
- `npm pack --dry-run --json` — package contains executable `aislop-tools`
- npm 11 consumer install with lifecycle scripts disabled — CLI and installer linked, CLI reports 0.14.0
- npm 12.0.1 consumer install with default secure lifecycle behavior — 195 packages installed, no package postinstall, CLI and installer executable, CLI reports 0.14.0
- npm 11 and npm 12.0.1 publish dry-runs — package normalization passed and the tarball retained all three executable bins

## Required before the v0.14.0 release

Configure the `aislop` npm package trusted publisher as GitHub Actions with:

- organization: `scanaislop`
- repository: `aislop`
- workflow: `release.yml`
- allowed action: `npm publish`

Complete this before publishing the GitHub Release so the tokenless npm job can authenticate.
