### PR TITLE
fix(scanner): address final v0.14 review findings

### DIFF
--- a/src/engines/ai-slop/test-quality.ts
+++ b/src/engines/ai-slop/test-quality.ts
@@ -71,7 +71,7 @@ const parseStringLiteral = (rawValue: string): string | null => {
 			const decoded = parseHexEscape(digits);
 			if (decoded === null) return null;
 			value += decoded;
-			index = end;
+			index = hasBraces ? end : end - 1;
 			continue;
 		}
 		value += escapeCode;

--- a/src/utils/source-file-selection.ts
+++ b/src/utils/source-file-selection.ts
@@ -41,7 +41,7 @@ const normalizeExcludePatterns = (patterns: string[]): string[] =>
 		if (normalized.length > MAX_GLOB_PATTERN_LENGTH) return [];
 		if (micromatch.scan(normalized).isGlob) return [normalized];
 		if (normalized.startsWith(".") && !normalized.includes("/")) {
-			return supportedGlobPatterns([`**/*${normalized}`, `**/${normalized}/**`]);
+			return supportedGlobPatterns([`**/${normalized}`, `**/${normalized}/**`]);
 		}
 		return supportedGlobPatterns([normalized, `${normalized}/**`]);
 	});

--- a/tests/cli-ergonomics.test.ts
+++ b/tests/cli-ergonomics.test.ts
@@ -64,6 +64,7 @@ const PUBLIC_HELP_COMMANDS: string[][] = [
 	["version", "--help"],
 	["commands", "--help"],
 ];
+const PUBLIC_HELP_TIMEOUT_MS = process.platform === "win32" ? 120_000 : 60_000;
 
 describe("cli ergonomics", () => {
 	it("uses the installed command in top-level help and keeps npx for one-off latest runs", () => {
@@ -168,7 +169,7 @@ describe("cli ergonomics", () => {
 			expect(result.stderr, label).not.toContain("too many arguments");
 			expect(result.stderr, label).not.toContain("unknown command");
 		}
-	}, 60_000);
+	}, PUBLIC_HELP_TIMEOUT_MS);
 
 	it("keeps existing core command help complete and aligned with registered flags", () => {
 		const scan = runCli(["scan", "--help"]);

--- a/tests/source-file-excludes.test.ts
+++ b/tests/source-file-excludes.test.ts
@@ -48,15 +48,19 @@ describe("exclude pattern normalization", () => {
 		createFile(".hidden.ts");
 		createFile("src/.hidden.ts");
 		createFile("src/app.ts");
+		createFile("src/foo.hidden.ts");
 
 		const filtered = filterEnumeratedProjectFiles(
 			tmpDir,
-			[".hidden.ts", "src/.hidden.ts", "src/app.ts"],
+			[".hidden.ts", "src/.hidden.ts", "src/app.ts", "src/foo.hidden.ts"],
 			[],
 			[".hidden.ts"],
 		);
 
-		expect(filtered).toEqual([path.join(tmpDir, "src/app.ts")]);
+		expect(filtered).toEqual([
+			path.join(tmpDir, "src/app.ts"),
+			path.join(tmpDir, "src/foo.hidden.ts"),
+		]);
 	});
 
 	it.each(["", "   ", "./", "/", "///"])("ignores empty or root-like exclusion %j", (exclude) => {

--- a/tests/test-quality.test.ts
+++ b/tests/test-quality.test.ts
@@ -59,6 +59,7 @@ describe("tautological test assertions", () => {
 			[
 				`it("matches strings", () => { expect("ok").toBe('ok'); });`,
 				"it('matches numbers', () => { assert.strictEqual(1.0, 1); });",
+				String.raw`it("matches escapes", () => { expect("\u0041b").toBe("Ab"); });`,
 			].join("\n"),
 		);
 
@@ -67,6 +68,7 @@ describe("tautological test assertions", () => {
 		expect(result.diagnostics.filter((d) => d.rule === "ai-slop/tautological-test")).toEqual([
 			expect.objectContaining({ filePath: "src/value.test.ts", line: 1 }),
 			expect.objectContaining({ filePath: "src/value.test.ts", line: 2 }),
+			expect.objectContaining({ filePath: "src/value.test.ts", line: 3 }),
 		]);
 	});
 


### PR DESCRIPTION
## Summary

- make literal dotfile excludes match the exact path segment instead of any filename with the same suffix
- preserve root and nested dotfile exclusion behavior
- add regression coverage proving `.hidden.ts` does not exclude `foo.hidden.ts`
- preserve the character after non-braced Unicode escapes when comparing fixed test literals
- give the Windows CLI help matrix enough headroom for its 40 subprocess checks

## Validation

- both scanner regression tests failed before their implementation changes
- `pnpm vitest run tests/test-quality.test.ts tests/cli-ergonomics.test.ts tests/source-file-excludes.test.ts` — 35 tests passed
- `pnpm quality` — 167 test files / 1,553 tests passed
- telemetry-free self-scan — 100/100, 428 supported files, 0 findings

Follow-up to the suppressed dotfile review note and the Unicode escape inline comment on #294. The Windows timeout adjustment addresses the only failing hosted matrix leg from the first #299 run.
