### PR TITLE
fix(scanner): harden project file enumeration

### DIFF
--- a/src/utils/project-file-list.ts
+++ b/src/utils/project-file-list.ts
@@ -4,11 +4,21 @@ import path from "node:path";
 
 const MAX_BUFFER = 50 * 1024 * 1024;
 
+const normalizePruneDirectories = (directories: Set<string>): Set<string> =>
+	new Set([...directories].map((directory) => directory.toLowerCase()));
+
+const isInPrunedDirectory = (filePath: string, pruneDirectories: Set<string>): boolean => {
+	const pathSegments = filePath.split("/");
+	pathSegments.pop();
+	return pathSegments.some((segment) => pruneDirectories.has(segment.toLowerCase()));
+};
+
 export const enumerateProjectFilesFromDisk = (
 	rootDirectory: string,
 	pruneDirectories: Set<string>,
 ): string[] => {
 	const files: string[] = [];
+	const normalizedPruneDirectories = normalizePruneDirectories(pruneDirectories);
 	const walk = (directory: string): void => {
 		let entries: fs.Dirent[];
 		try {
@@ -18,8 +28,21 @@ export const enumerateProjectFilesFromDisk = (
 		}
 		for (const entry of entries) {
 			const fullPath = path.join(directory, entry.name);
+			if (entry.isSymbolicLink()) continue;
 			if (entry.isDirectory()) {
-				if (!pruneDirectories.has(entry.name)) walk(fullPath);
+				let stats: fs.Stats;
+				try {
+					stats = fs.lstatSync(fullPath);
+				} catch {
+					continue;
+				}
+				if (
+					stats.isDirectory() &&
+					!stats.isSymbolicLink() &&
+					!normalizedPruneDirectories.has(entry.name.toLowerCase())
+				) {
+					walk(fullPath);
+				}
 			} else if (entry.isFile()) {
 				files.push(path.relative(rootDirectory, fullPath).split(path.sep).join("/"));
 			}
@@ -40,9 +63,11 @@ export const enumerateProjectFiles = (
 	});
 
 	if (!result.error && result.status === 0) {
+		const normalizedPruneDirectories = normalizePruneDirectories(pruneDirectories);
 		return result.stdout
 			.split("\n")
 			.filter((file) => file.length > 0)
+			.filter((file) => !isInPrunedDirectory(file, normalizedPruneDirectories))
 			.filter((file) => fs.existsSync(path.resolve(rootDirectory, file)));
 	}
 

--- a/tests/project-file-list.test.ts
+++ b/tests/project-file-list.test.ts
@@ -1,0 +1,59 @@
+import { execFileSync } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+	enumerateProjectFiles,
+	enumerateProjectFilesFromDisk,
+} from "../src/utils/project-file-list.js";
+
+const writeFile = (rootDirectory: string, relativePath: string): void => {
+	const filePath = path.join(rootDirectory, relativePath);
+	fs.mkdirSync(path.dirname(filePath), { recursive: true });
+	fs.writeFileSync(filePath, "export {};\n", "utf-8");
+};
+
+describe("project file enumeration", () => {
+	let rootDirectory: string;
+
+	beforeEach(() => {
+		rootDirectory = fs.mkdtempSync(path.join(os.tmpdir(), "aislop-project-files-"));
+	});
+
+	afterEach(() => {
+		fs.rmSync(rootDirectory, { recursive: true, force: true });
+	});
+
+	it("prunes tracked and untracked directories from git enumeration", () => {
+		execFileSync("git", ["init"], { cwd: rootDirectory, stdio: "ignore" });
+		writeFile(rootDirectory, "src/app.ts");
+		writeFile(rootDirectory, "vendor/tracked.ts");
+		writeFile(rootDirectory, "dist/untracked.js");
+		execFileSync("git", ["add", "-f", "src/app.ts", "vendor/tracked.ts"], {
+			cwd: rootDirectory,
+			stdio: "ignore",
+		});
+
+		expect(enumerateProjectFiles(rootDirectory, new Set(["dist", "vendor"]))).toEqual([
+			"src/app.ts",
+		]);
+	});
+
+	it("does not follow directory symlinks or junctions during disk enumeration", () => {
+		const outsideDirectory = fs.mkdtempSync(path.join(os.tmpdir(), "aislop-project-outside-"));
+		try {
+			writeFile(rootDirectory, "src/app.ts");
+			writeFile(outsideDirectory, "escaped.ts");
+			fs.symlinkSync(
+				outsideDirectory,
+				path.join(rootDirectory, "linked"),
+				process.platform === "win32" ? "junction" : "dir",
+			);
+
+			expect(enumerateProjectFilesFromDisk(rootDirectory, new Set())).toEqual(["src/app.ts"]);
+		} finally {
+			fs.rmSync(outsideDirectory, { recursive: true, force: true });
+		}
+	});
+});


### PR DESCRIPTION
## Summary

- prune configured directories from both tracked and untracked `git ls-files` results
- explicitly reject symlink and junction entries before disk-walk recursion
- revalidate directory entries with `lstat` before descending
- add direct tracked, untracked, symlink, and junction regression coverage

## Reviewer context

This addresses the two remaining project-file enumeration comments on #294. The separate declaration-evidence comment is already covered on current `develop` by `filterProjectDeclarationFiles` and its regression tests.

## Validation

- focused regression: 3 files, 13 tests
- full suite: 168 files, 1,555 tests
- telemetry-free Aislop self-scan: 100/100 over 429 files, 0 findings
- Biome and TypeScript checks pass

All scans used `AISLOP_NO_TELEMETRY=1`, `AISLOP_NO_HISTORY=1`, `AISLOP_NO_UPDATE_NOTIFIER=1`, `DO_NOT_TRACK=1`, and `CI=1`.

Closes the outstanding review feedback on #294 without merging #294.
