### PR TITLE
fix(scanner): scope language discovery to scan files

### DIFF
--- a/src/commands/scan.ts
+++ b/src/commands/scan.ts
@@ -11,7 +11,7 @@ import { type EngineCounts, withCommandLifecycle } from "../telemetry/index.js";
 import { renderDisplayRows } from "../ui/display.js";
 import { renderHeader } from "../ui/header.js";
 import { log } from "../ui/logger.js";
-import { discoverProject } from "../utils/discover.js";
+import { detectSourceLanguages, discoverProject } from "../utils/discover.js";
 import { baseRefExists } from "../utils/git.js";
 import { appendHistory } from "../utils/history.js";
 import { readAislopIgnorePatterns } from "../utils/source-files.js";
@@ -92,15 +92,19 @@ export const scanCommand = async (
 	}
 
 	const excludePatterns = [...config.exclude, ...readAislopIgnorePatterns(resolvedDir)];
-	const projectInfo = await discoverProject(resolvedDir, excludePatterns, {
-		includePatterns: config.include,
-	});
 	const scanScope = collectScanFileScope({
 		excludePatterns,
 		includePatterns: config.include,
 		mode: resolveScanScopeMode(options),
 		rootDirectory: resolvedDir,
 	});
+	const discoveredProject = await discoverProject(resolvedDir, excludePatterns, {
+		includePatterns: config.include,
+	});
+	const projectInfo = {
+		...discoveredProject,
+		languages: detectSourceLanguages([...scanScope.files, ...scanScope.testFiles]),
+	};
 
 	return withCommandLifecycle(
 		{

--- a/src/utils/discover.ts
+++ b/src/utils/discover.ts
@@ -131,13 +131,19 @@ const readPackageJson = (filePath: string): PackageJson | null => {
 	}
 };
 
-const detectLanguages = (directory: string, sourceFiles: string[]): Language[] => {
+export const detectSourceLanguages = (sourceFiles: string[]): Language[] => {
 	const languages = new Set<Language>();
 
 	for (const sourceFile of sourceFiles) {
 		const lang = EXTENSION_LANGUAGES[path.extname(sourceFile).toLowerCase()];
 		if (lang) languages.add(lang);
 	}
+
+	return [...languages];
+};
+
+const detectLanguages = (directory: string, sourceFiles: string[]): Language[] => {
+	const languages = new Set<Language>(detectSourceLanguages(sourceFiles));
 
 	for (const [file, lang] of Object.entries(LANGUAGE_SIGNALS)) {
 		if (fs.existsSync(path.join(directory, file))) {

--- a/tests/audit-gate.test.ts
+++ b/tests/audit-gate.test.ts
@@ -22,7 +22,7 @@ const pythonContext = (rootDirectory: string): EngineContext =>
 		config: { security: { auditTimeout: 1000 } },
 	}) as unknown as EngineContext;
 
-describe("runDependencyAudit — Python dependency-manifest gate", () => {
+describe("runDependencyAudit: Python dependency-manifest gate", () => {
 	let dir: string;
 
 	beforeEach(() => {

--- a/tests/complexity.test.ts
+++ b/tests/complexity.test.ts
@@ -208,7 +208,7 @@ describe("checkComplexity — function too long", () => {
 	});
 });
 
-describe("analyzeFunctions — braces inside strings/comments don't skew length", () => {
+describe("analyzeFunctions: braces inside strings/comments don't skew length", () => {
 	it("does not count a brace inside a line comment as opening a block", () => {
 		const content = [
 			"function tiny(a: number) {",
@@ -252,7 +252,7 @@ describe("analyzeFunctions — braces inside strings/comments don't skew length"
 	});
 });
 
-describe("analyzeFunctions — Python end-detection uses masked lines", () => {
+describe("analyzeFunctions: Python end-detection uses masked lines", () => {
 	it("does not truncate a Python function at a comment dedented to column 0", () => {
 		const content = [
 			"def f():",

--- a/tests/scan-language-scope.test.ts
+++ b/tests/scan-language-scope.test.ts
@@ -1,0 +1,69 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { DEFAULT_CONFIG } from "../src/config/defaults.js";
+import type { AislopConfig } from "../src/config/index.js";
+
+const { runEnginesWithProgress } = vi.hoisted(() => ({
+	runEnginesWithProgress: vi.fn(),
+}));
+
+vi.mock("../src/commands/scan-engine-runner.js", () => ({ runEnginesWithProgress }));
+
+const { scanCommand } = await import("../src/commands/scan.js");
+
+const writeFile = (rootDirectory: string, relativePath: string, content: string): string => {
+	const filePath = path.join(rootDirectory, relativePath);
+	fs.mkdirSync(path.dirname(filePath), { recursive: true });
+	fs.writeFileSync(filePath, content, "utf-8");
+	return filePath;
+};
+
+describe("scan language scope", () => {
+	let rootDirectory: string;
+
+	beforeEach(() => {
+		rootDirectory = fs.mkdtempSync(path.join(os.tmpdir(), "aislop-scan-language-"));
+		runEnginesWithProgress.mockReset();
+		runEnginesWithProgress.mockResolvedValue([]);
+		vi.spyOn(console, "log").mockImplementation(() => undefined);
+	});
+
+	afterEach(() => {
+		vi.restoreAllMocks();
+		fs.rmSync(rootDirectory, { recursive: true, force: true });
+	});
+
+	it("does not enable languages found only outside the selected files", async () => {
+		const selectedFile = writeFile(rootDirectory, "src/web/app.ts", "export const app = true;\n");
+		writeFile(rootDirectory, "native/main.go", "package main\n");
+		writeFile(rootDirectory, "go.mod", "module example.com/app\n\ngo 1.24\n");
+		writeFile(rootDirectory, "tsconfig.json", "{}\n");
+
+		const config: AislopConfig = {
+			...DEFAULT_CONFIG,
+			include: ["src/web"],
+			security: { ...DEFAULT_CONFIG.security, audit: false },
+			telemetry: { enabled: false },
+		};
+
+		await scanCommand(rootDirectory, config, {
+			changes: false,
+			staged: false,
+			verbose: false,
+			json: true,
+			showHeader: false,
+			printBrand: false,
+		});
+
+		expect(runEnginesWithProgress).toHaveBeenCalledWith(
+			expect.objectContaining({
+				files: [selectedFile],
+				languages: ["typescript"],
+			}),
+			config.engines,
+			true,
+		);
+	});
+});

--- a/tests/source-masker.test.ts
+++ b/tests/source-masker.test.ts
@@ -83,7 +83,7 @@ describe("maskStringsAndComments still masks string bodies", () => {
 
 describe("maskStringsAndComments recognises regex literals", () => {
 	// A regex whose body contains quotes/backticks/comment markers must not be read as
-	// a string/template/comment — otherwise the scanner desyncs and blanks real code.
+	// a string/template/comment; otherwise the scanner desyncs and blanks real code.
 	it("does not let a quote inside a regex swallow following code", () => {
 		const src = ["const re = /(?:`|[\"'])\\s*/;", 'const kept = "after";', ""].join("\n");
 		const out = maskStringsAndComments(src, ".ts");


### PR DESCRIPTION
## Summary

- derive scan engine languages from the selected production and test files
- prevent unrelated root-level language tools from activating for `--include`, `--staged`, and `--changes` scopes
- add an integration regression for a TypeScript include inside a mixed TypeScript/Go repository
- replace the four non-ASCII em dashes introduced by this release in test and comment prose

## Reviewer context

This addresses the two final Codex review comments on #294 without merging #294.

## Validation

- focused regression: 5 files, 69 tests
- full suite: 169 files, 1,556 tests
- telemetry-free Aislop self-scan: 100/100 over 430 files, 0 findings
- Biome, TypeScript, whitespace, and introduced-em-dash checks pass

All scans used `AISLOP_NO_TELEMETRY=1`, `AISLOP_NO_HISTORY=1`, `AISLOP_NO_UPDATE_NOTIFIER=1`, `DO_NOT_TRACK=1`, and `CI=1`.
