### PR TITLE
fix(release): add guarded npm v12 recovery

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,9 +24,61 @@ permissions:
   contents: read
 
 jobs:
+  resolve-release:
+    name: Resolve release
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    outputs:
+      prerelease: ${{ steps.release.outputs.prerelease }}
+      sha: ${{ steps.release.outputs.sha }}
+      tag: ${{ steps.release.outputs.tag }}
+
+    steps:
+      - name: Resolve release
+        id: release
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_TAG: ${{ github.event.release.tag_name || inputs.tag }}
+        run: |
+          set -euo pipefail
+          if ! [[ "$RELEASE_TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?$ ]]; then
+            echo "Release tag must be a semantic version prefixed with v" >&2
+            exit 1
+          fi
+
+          release_data="$(gh api "repos/$GITHUB_REPOSITORY/releases/tags/$RELEASE_TAG" --jq '[.draft, .prerelease, .published_at] | @tsv')"
+          IFS=$'\t' read -r draft prerelease published_at <<< "$release_data"
+
+          if [ "$draft" != "false" ] || [ -z "$published_at" ] || [ "$published_at" = "null" ]; then
+            echo "Release tag must belong to a published GitHub Release" >&2
+            exit 1
+          fi
+
+          ref_data="$(gh api "repos/$GITHUB_REPOSITORY/git/ref/tags/$RELEASE_TAG" --jq '[.object.type, .object.sha] | @tsv')"
+          IFS=$'\t' read -r object_type object_sha <<< "$ref_data"
+
+          if [ "$object_type" = "tag" ]; then
+            tag_data="$(gh api "repos/$GITHUB_REPOSITORY/git/tags/$object_sha" --jq '[.object.type, .object.sha] | @tsv')"
+            IFS=$'\t' read -r object_type object_sha <<< "$tag_data"
+          fi
+
+          if [ "$object_type" != "commit" ]; then
+            echo "Release tag does not resolve to a commit" >&2
+            exit 1
+          fi
+
+          {
+            echo "prerelease=$prerelease"
+            echo "sha=$object_sha"
+            echo "tag=$RELEASE_TAG"
+          } >> "$GITHUB_OUTPUT"
+
   publish-npm:
     name: Publish to npm
     runs-on: ubuntu-latest
+    needs: resolve-release
     permissions:
       contents: read
       id-token: write
@@ -34,7 +86,7 @@ jobs:
     steps:
       - uses: actions/checkout@v7
         with:
-          ref: ${{ github.event.release.tag_name || inputs.tag }}
+          ref: ${{ needs.resolve-release.outputs.sha }}
 
       - uses: pnpm/action-setup@v6
 
@@ -49,7 +101,7 @@ jobs:
 
       - name: Verify release tag
         env:
-          RELEASE_TAG: ${{ github.event.release.tag_name || inputs.tag }}
+          RELEASE_TAG: ${{ needs.resolve-release.outputs.tag }}
         run: |
           expected_tag="v$(node -p 'require("./package.json").version')"
           if [ "$RELEASE_TAG" != "$expected_tag" ]; then
@@ -96,7 +148,7 @@ jobs:
   publish-gpr:
     name: Publish to GitHub Packages
     runs-on: ubuntu-latest
-    needs: publish-npm
+    needs: [resolve-release, publish-npm]
     if: ${{ github.event_name == 'release' || inputs.publish }}
     permissions:
       contents: read
@@ -105,7 +157,7 @@ jobs:
     steps:
       - uses: actions/checkout@v7
         with:
-          ref: ${{ github.event.release.tag_name || inputs.tag }}
+          ref: ${{ needs.resolve-release.outputs.sha }}
 
       - uses: pnpm/action-setup@v6
 
@@ -133,11 +185,15 @@ jobs:
   move-major-tag:
     name: Move v1 Action tag to this release
     runs-on: ubuntu-latest
-    needs: publish-npm
+    needs: [resolve-release, publish-npm]
     if: >-
       ${{
-        (github.event_name == 'release' && !github.event.release.prerelease) ||
-        (github.event_name == 'workflow_dispatch' && inputs.publish && inputs.move-major-tag)
+        (github.event_name == 'release' &&
+          needs.resolve-release.outputs.prerelease == 'false') ||
+        (github.event_name == 'workflow_dispatch' &&
+          inputs.publish &&
+          inputs.move-major-tag &&
+          needs.resolve-release.outputs.prerelease == 'false')
       }}
     permissions:
       contents: write
@@ -145,9 +201,9 @@ jobs:
     steps:
       - uses: actions/checkout@v7
         with:
-          ref: ${{ github.event.release.tag_name || inputs.tag }}
+          ref: ${{ needs.resolve-release.outputs.sha }}
 
-      - name: Re-point v1 to ${{ github.event.release.tag_name || inputs.tag }}
+      - name: Re-point v1 to ${{ needs.resolve-release.outputs.tag }}
         run: |
           git tag -f v1
           git push origin v1 --force

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,6 +3,22 @@ name: Release
 on:
   release:
     types: [published]
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: Existing release tag to recover
+        required: true
+        type: string
+      publish:
+        description: Publish after the trusted publishing preflight passes
+        required: true
+        default: false
+        type: boolean
+      move-major-tag:
+        description: Move v1 after publishing a stable release
+        required: true
+        default: false
+        type: boolean
 
 permissions:
   contents: read
@@ -18,7 +34,7 @@ jobs:
     steps:
       - uses: actions/checkout@v7
         with:
-          ref: ${{ github.event.release.tag_name }}
+          ref: ${{ github.event.release.tag_name || inputs.tag }}
 
       - uses: pnpm/action-setup@v6
 
@@ -27,6 +43,19 @@ jobs:
           node-version: 24
           package-manager-cache: false
           registry-url: https://registry.npmjs.org
+
+      - name: Install npm 12
+        run: npm install --global npm@12.0.1
+
+      - name: Verify release tag
+        env:
+          RELEASE_TAG: ${{ github.event.release.tag_name || inputs.tag }}
+        run: |
+          expected_tag="v$(node -p 'require("./package.json").version')"
+          if [ "$RELEASE_TAG" != "$expected_tag" ]; then
+            echo "Release tag $RELEASE_TAG does not match package version $expected_tag" >&2
+            exit 1
+          fi
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
@@ -48,13 +77,27 @@ jobs:
           AISLOP_NO_UPDATE_NOTIFIER: "1"
           DO_NOT_TRACK: "1"
 
+      - name: Verify npm trusted publishing
+        shell: bash
+        run: |
+          set -euo pipefail
+          log_file="$(mktemp)"
+          trap 'rm -f "$log_file"' EXIT
+          npm publish --access public --dry-run --loglevel verbose 2>&1 | tee "$log_file"
+          if ! grep -Fq "Successfully retrieved and set token" "$log_file"; then
+            echo "npm trusted publishing token exchange failed" >&2
+            exit 1
+          fi
+
       - name: Publish to npm
+        if: ${{ github.event_name == 'release' || inputs.publish }}
         run: npm publish --access public
 
   publish-gpr:
     name: Publish to GitHub Packages
     runs-on: ubuntu-latest
     needs: publish-npm
+    if: ${{ github.event_name == 'release' || inputs.publish }}
     permissions:
       contents: read
       packages: write
@@ -62,7 +105,7 @@ jobs:
     steps:
       - uses: actions/checkout@v7
         with:
-          ref: ${{ github.event.release.tag_name }}
+          ref: ${{ github.event.release.tag_name || inputs.tag }}
 
       - uses: pnpm/action-setup@v6
 
@@ -91,16 +134,20 @@ jobs:
     name: Move v1 Action tag to this release
     runs-on: ubuntu-latest
     needs: publish-npm
-    if: ${{ !github.event.release.prerelease }}
+    if: >-
+      ${{
+        (github.event_name == 'release' && !github.event.release.prerelease) ||
+        (github.event_name == 'workflow_dispatch' && inputs.publish && inputs.move-major-tag)
+      }}
     permissions:
       contents: write
 
     steps:
       - uses: actions/checkout@v7
         with:
-          ref: ${{ github.event.release.tag_name }}
+          ref: ${{ github.event.release.tag_name || inputs.tag }}
 
-      - name: Re-point v1 to ${{ github.event.release.tag_name }}
+      - name: Re-point v1 to ${{ github.event.release.tag_name || inputs.tag }}
         run: |
           git tag -f v1
           git push origin v1 --force

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -121,7 +121,7 @@ This applies to regex patterns, string literals, and diagnostic messages in all 
 
 - **Branch model**: branch from current `origin/develop`; open PRs to `develop` unless the task explicitly says otherwise.
 - **Main promotion**: `develop` -> `main` is a maintainer decision. Do not merge it just because checks are green.
-- **Releases**: automated via `.github/workflows/release.yml` on `v*` tags.
+- **Releases**: publishing a GitHub Release runs `.github/workflows/release.yml`; failed npm publishes can use its guarded manual recovery after promotion to `main`.
 - **CI**: Node 22 + 24 matrix, typecheck + build + test + self-scan.
 - All changes should pass: `pnpm typecheck && pnpm test && pnpm scan`.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -258,6 +258,15 @@ The npm package's trusted publisher must match these values exactly:
 - Workflow filename: `release.yml`
 - Allowed action: `npm publish`
 
+If npm publication fails after the GitHub Release is published, do not move or
+recreate the release tag. Promote the recovery workflow to the default branch,
+then run `Release` manually with the existing tag and leave both boolean inputs
+disabled. This performs the npm OIDC preflight without publishing. After that
+preflight succeeds, a maintainer may run it again with `publish` enabled.
+Enable `move-major-tag` only for a stable release. The recovery workflow accepts
+published GitHub Release tags and checks out their resolved commit, not a branch
+or arbitrary ref.
+
 Version bumps follow [semver](https://semver.org/):
 
 - **patch** -- bug fixes, false-positive fixes

--- a/tests/package-release-security.test.ts
+++ b/tests/package-release-security.test.ts
@@ -20,6 +20,8 @@ const WorkflowStepSchema = z.object({
 
 const WorkflowJobSchema = z.object({
 	if: z.string().optional(),
+	needs: z.union([z.string(), z.array(z.string())]).optional(),
+	outputs: z.record(z.string(), z.string()).optional(),
 	permissions: z.record(z.string(), z.string()),
 	steps: z.array(WorkflowStepSchema),
 });
@@ -52,6 +54,7 @@ const ReleaseWorkflowSchema = z.object({
 		"move-major-tag": WorkflowJobSchema,
 		"publish-gpr": WorkflowJobSchema,
 		"publish-npm": WorkflowJobSchema,
+		"resolve-release": WorkflowJobSchema,
 	}),
 	permissions: z.record(z.string(), z.string()),
 });
@@ -95,17 +98,61 @@ describe("package release security", () => {
 		expect(workflow.jobs["move-major-tag"].permissions).toEqual({ contents: "write" });
 	});
 
-	it("supports a guarded manual recovery for an existing release tag", () => {
+	it("resolves an existing GitHub release before executing its code", () => {
+		const workflow = ReleaseWorkflowSchema.parse(
+			parseYaml(fs.readFileSync(".github/workflows/release.yml", "utf8")),
+		);
+		const resolveJob = workflow.jobs["resolve-release"];
+		const resolveStep = resolveJob.steps.find((step) => step.name === "Resolve release");
+		const resolvedSha = "${{ needs.resolve-release.outputs.sha }}";
+		const checkoutRefs = [
+			workflow.jobs["publish-npm"],
+			workflow.jobs["publish-gpr"],
+			workflow.jobs["move-major-tag"],
+		].map((job) => job.steps.find((step) => step.uses?.startsWith("actions/checkout@"))?.with?.ref);
+
+		expect(resolveJob.permissions).toEqual({ contents: "read" });
+		expect(resolveJob.outputs).toEqual({
+			prerelease: "${{ steps.release.outputs.prerelease }}",
+			sha: "${{ steps.release.outputs.sha }}",
+			tag: "${{ steps.release.outputs.tag }}",
+		});
+		expect(resolveJob.steps.some((step) => step.uses?.startsWith("actions/checkout@"))).toBe(false);
+		expect(resolveStep?.env).toEqual({
+			GH_TOKEN: "${{ github.token }}",
+			RELEASE_TAG: "${{ github.event.release.tag_name || inputs.tag }}",
+		});
+		expect(resolveStep?.run).toContain(
+			'[[ "$RELEASE_TAG" =~ ^v[0-9]+\\.[0-9]+\\.[0-9]+(-[0-9A-Za-z.-]+)?$ ]]',
+		);
+		expect(resolveStep?.run).toContain(
+			'gh api "repos/$GITHUB_REPOSITORY/releases/tags/$RELEASE_TAG"',
+		);
+		expect(resolveStep?.run).toContain("[.draft, .prerelease, .published_at] | @tsv");
+		expect(resolveStep?.run).toContain('if [ "$draft" != "false" ]');
+		expect(resolveStep?.run).toContain('[ "$published_at" = "null" ]');
+		expect(resolveStep?.run).toContain(
+			'gh api "repos/$GITHUB_REPOSITORY/git/ref/tags/$RELEASE_TAG"',
+		);
+		expect(resolveStep?.run).toContain('if [ "$object_type" != "commit" ]');
+		expect(checkoutRefs).toEqual([resolvedSha, resolvedSha, resolvedSha]);
+		expect(workflow.jobs["publish-npm"].needs).toBe("resolve-release");
+		expect(workflow.jobs["publish-gpr"].needs).toEqual(["resolve-release", "publish-npm"]);
+		expect(workflow.jobs["move-major-tag"].needs).toEqual(["resolve-release", "publish-npm"]);
+	});
+
+	it("keeps manual recovery non-publishing unless explicitly enabled", () => {
 		const workflow = ReleaseWorkflowSchema.parse(
 			parseYaml(fs.readFileSync(".github/workflows/release.yml", "utf8")),
 		);
 		const npmJob = workflow.jobs["publish-npm"];
-		const releaseRef = "${{ github.event.release.tag_name || inputs.tag }}";
-		const checkoutRefs = Object.values(workflow.jobs).map(
-			(job) => job.steps.find((step) => step.uses?.startsWith("actions/checkout@"))?.with?.ref,
-		);
 		const verifyTag = npmJob.steps.find((step) => step.name === "Verify release tag");
 		const verifyTrust = npmJob.steps.find((step) => step.name === "Verify npm trusted publishing");
+		const publish = npmJob.steps.find((step) => step.name === "Publish to npm");
+		const publishCondition = "${{ github.event_name == 'release' || inputs.publish }}";
+		const stableRelease = "needs.resolve-release.outputs.prerelease == 'false'";
+		const expressionStart = "${{";
+		const moveMajorCondition = workflow.jobs["move-major-tag"].if?.replace(/\s+/g, " ").trim();
 
 		expect(workflow.on.release.types).toEqual(["published"]);
 		expect(workflow.on.workflow_dispatch.inputs.tag).toMatchObject({
@@ -122,18 +169,18 @@ describe("package release security", () => {
 			required: true,
 			type: "boolean",
 		});
-		expect(checkoutRefs).toEqual([releaseRef, releaseRef, releaseRef]);
-		expect(verifyTag?.env).toEqual({ RELEASE_TAG: releaseRef });
+		expect(verifyTag?.env).toEqual({ RELEASE_TAG: "${{ needs.resolve-release.outputs.tag }}" });
 		expect(verifyTag?.run).toContain('expected_tag="v$(node -p');
 		expect(verifyTag?.run).toContain('if [ "$RELEASE_TAG" != "$expected_tag" ]');
 		expect(verifyTrust?.shell).toBe("bash");
 		expect(verifyTrust?.run).toContain("npm publish --access public --dry-run --loglevel verbose");
 		expect(verifyTrust?.run).toContain('grep -Fq "Successfully retrieved and set token"');
-		expect(npmJob.steps.find((step) => step.name === "Publish to npm")?.if).toContain(
-			"inputs.publish",
+		expect(publish?.if).toBe(publishCondition);
+		expect(workflow.jobs["publish-gpr"].if).toBe(publishCondition);
+		expect(moveMajorCondition).toBe(
+			`${expressionStart} (github.event_name == 'release' && ${stableRelease}) || ` +
+				`(github.event_name == 'workflow_dispatch' && inputs.publish && ` +
+				`inputs.move-major-tag && ${stableRelease}) }}`,
 		);
-		expect(workflow.jobs["publish-gpr"].if).toContain("inputs.publish");
-		expect(workflow.jobs["move-major-tag"].if).toContain("inputs.move-major-tag");
-		expect(workflow.jobs["move-major-tag"].if).toContain("inputs.publish");
 	});
 });

--- a/tests/package-release-security.test.ts
+++ b/tests/package-release-security.test.ts
@@ -10,18 +10,44 @@ const PackageManifestSchema = z.object({
 
 const WorkflowStepSchema = z.object({
 	env: z.record(z.string(), z.string()).optional(),
+	if: z.string().optional(),
 	name: z.string().optional(),
 	run: z.string().optional(),
+	shell: z.string().optional(),
 	uses: z.string().optional(),
 	with: z.record(z.string(), z.unknown()).optional(),
 });
 
 const WorkflowJobSchema = z.object({
+	if: z.string().optional(),
 	permissions: z.record(z.string(), z.string()),
 	steps: z.array(WorkflowStepSchema),
 });
 
 const ReleaseWorkflowSchema = z.object({
+	on: z.object({
+		release: z.object({
+			types: z.array(z.string()),
+		}),
+		workflow_dispatch: z.object({
+			inputs: z.object({
+				"move-major-tag": z.object({
+					default: z.boolean(),
+					required: z.boolean(),
+					type: z.literal("boolean"),
+				}),
+				publish: z.object({
+					default: z.boolean(),
+					required: z.boolean(),
+					type: z.literal("boolean"),
+				}),
+				tag: z.object({
+					required: z.boolean(),
+					type: z.literal("string"),
+				}),
+			}),
+		}),
+	}),
 	jobs: z.object({
 		"move-major-tag": WorkflowJobSchema,
 		"publish-gpr": WorkflowJobSchema,
@@ -49,6 +75,7 @@ describe("package release security", () => {
 		const workflow = ReleaseWorkflowSchema.parse(parseYaml(workflowSource));
 		const npmJob = workflow.jobs["publish-npm"];
 		const setupNode = npmJob.steps.find((step) => step.uses?.startsWith("actions/setup-node@"));
+		const installNpm = npmJob.steps.find((step) => step.name === "Install npm 12");
 		const publish = npmJob.steps.find((step) => step.name === "Publish to npm");
 
 		expect(workflow.permissions).toEqual({ contents: "read" });
@@ -57,6 +84,7 @@ describe("package release security", () => {
 			"node-version": 24,
 			"package-manager-cache": false,
 		});
+		expect(installNpm?.run).toBe("npm install --global npm@12.0.1");
 		expect(publish?.run).toBe("npm publish --access public");
 		expect(publish?.env).toBeUndefined();
 		expect(workflowSource).not.toContain("secrets.NPM_TOKEN");
@@ -65,5 +93,47 @@ describe("package release security", () => {
 			packages: "write",
 		});
 		expect(workflow.jobs["move-major-tag"].permissions).toEqual({ contents: "write" });
+	});
+
+	it("supports a guarded manual recovery for an existing release tag", () => {
+		const workflow = ReleaseWorkflowSchema.parse(
+			parseYaml(fs.readFileSync(".github/workflows/release.yml", "utf8")),
+		);
+		const npmJob = workflow.jobs["publish-npm"];
+		const releaseRef = "${{ github.event.release.tag_name || inputs.tag }}";
+		const checkoutRefs = Object.values(workflow.jobs).map(
+			(job) => job.steps.find((step) => step.uses?.startsWith("actions/checkout@"))?.with?.ref,
+		);
+		const verifyTag = npmJob.steps.find((step) => step.name === "Verify release tag");
+		const verifyTrust = npmJob.steps.find((step) => step.name === "Verify npm trusted publishing");
+
+		expect(workflow.on.release.types).toEqual(["published"]);
+		expect(workflow.on.workflow_dispatch.inputs.tag).toMatchObject({
+			required: true,
+			type: "string",
+		});
+		expect(workflow.on.workflow_dispatch.inputs["move-major-tag"]).toEqual({
+			default: false,
+			required: true,
+			type: "boolean",
+		});
+		expect(workflow.on.workflow_dispatch.inputs.publish).toEqual({
+			default: false,
+			required: true,
+			type: "boolean",
+		});
+		expect(checkoutRefs).toEqual([releaseRef, releaseRef, releaseRef]);
+		expect(verifyTag?.env).toEqual({ RELEASE_TAG: releaseRef });
+		expect(verifyTag?.run).toContain('expected_tag="v$(node -p');
+		expect(verifyTag?.run).toContain('if [ "$RELEASE_TAG" != "$expected_tag" ]');
+		expect(verifyTrust?.shell).toBe("bash");
+		expect(verifyTrust?.run).toContain("npm publish --access public --dry-run --loglevel verbose");
+		expect(verifyTrust?.run).toContain('grep -Fq "Successfully retrieved and set token"');
+		expect(npmJob.steps.find((step) => step.name === "Publish to npm")?.if).toContain(
+			"inputs.publish",
+		);
+		expect(workflow.jobs["publish-gpr"].if).toContain("inputs.publish");
+		expect(workflow.jobs["move-major-tag"].if).toContain("inputs.move-major-tag");
+		expect(workflow.jobs["move-major-tag"].if).toContain("inputs.publish");
 	});
 });


### PR DESCRIPTION
## Summary

- pin npm 12 for npm Trusted Publisher releases and verify the OIDC exchange with a non-publishing dry run
- add a guarded manual recovery path for an existing published GitHub Release
- resolve the release tag to a commit before checkout and gate `v1` movement on stable release metadata
- document the preflight-first recovery procedure

## Validation

- `pnpm vitest run tests/package-release-security.test.ts` (4 tests)
- `pnpm quality` (169 files, 1,558 tests, Aislop 100/100)
- `npm pack --dry-run --json` (36 files)
- live read-only resolution of `v0.14.0` to `503fc6f57335c6e978bcfae82ec6bcf119634f6e`
- five read-only review lanes passed the exact commit

## Safety

No workflow was dispatched and no package, tag, or release was changed. Manual recovery defaults to preflight-only; publication requires an explicit input after the workflow reaches the default branch.
