### PR TITLE
chore: promote npm v12 release recovery

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -142,8 +142,14 @@ jobs:
           fi
 
       - name: Publish to npm
-        if: ${{ github.event_name == 'release' || inputs.publish }}
+        if: ${{ github.event_name == 'release' }}
         run: npm publish --access public
+
+      - name: Publish recovery to npm
+        if: ${{ github.event_name == 'workflow_dispatch' && inputs.publish }}
+        run: npm publish --access public
+        env:
+          NPM_CONFIG_PROVENANCE: "false"
 
   publish-gpr:
     name: Publish to GitHub Packages

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,14 +3,82 @@ name: Release
 on:
   release:
     types: [published]
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: Existing release tag to recover
+        required: true
+        type: string
+      publish:
+        description: Publish after the trusted publishing preflight passes
+        required: true
+        default: false
+        type: boolean
+      move-major-tag:
+        description: Move v1 after publishing a stable release
+        required: true
+        default: false
+        type: boolean
 
 permissions:
   contents: read
 
 jobs:
+  resolve-release:
+    name: Resolve release
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    outputs:
+      prerelease: ${{ steps.release.outputs.prerelease }}
+      sha: ${{ steps.release.outputs.sha }}
+      tag: ${{ steps.release.outputs.tag }}
+
+    steps:
+      - name: Resolve release
+        id: release
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_TAG: ${{ github.event.release.tag_name || inputs.tag }}
+        run: |
+          set -euo pipefail
+          if ! [[ "$RELEASE_TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?$ ]]; then
+            echo "Release tag must be a semantic version prefixed with v" >&2
+            exit 1
+          fi
+
+          release_data="$(gh api "repos/$GITHUB_REPOSITORY/releases/tags/$RELEASE_TAG" --jq '[.draft, .prerelease, .published_at] | @tsv')"
+          IFS=$'\t' read -r draft prerelease published_at <<< "$release_data"
+
+          if [ "$draft" != "false" ] || [ -z "$published_at" ] || [ "$published_at" = "null" ]; then
+            echo "Release tag must belong to a published GitHub Release" >&2
+            exit 1
+          fi
+
+          ref_data="$(gh api "repos/$GITHUB_REPOSITORY/git/ref/tags/$RELEASE_TAG" --jq '[.object.type, .object.sha] | @tsv')"
+          IFS=$'\t' read -r object_type object_sha <<< "$ref_data"
+
+          if [ "$object_type" = "tag" ]; then
+            tag_data="$(gh api "repos/$GITHUB_REPOSITORY/git/tags/$object_sha" --jq '[.object.type, .object.sha] | @tsv')"
+            IFS=$'\t' read -r object_type object_sha <<< "$tag_data"
+          fi
+
+          if [ "$object_type" != "commit" ]; then
+            echo "Release tag does not resolve to a commit" >&2
+            exit 1
+          fi
+
+          {
+            echo "prerelease=$prerelease"
+            echo "sha=$object_sha"
+            echo "tag=$RELEASE_TAG"
+          } >> "$GITHUB_OUTPUT"
+
   publish-npm:
     name: Publish to npm
     runs-on: ubuntu-latest
+    needs: resolve-release
     permissions:
       contents: read
       id-token: write
@@ -18,7 +86,7 @@ jobs:
     steps:
       - uses: actions/checkout@v7
         with:
-          ref: ${{ github.event.release.tag_name }}
+          ref: ${{ needs.resolve-release.outputs.sha }}
 
       - uses: pnpm/action-setup@v6
 
@@ -27,6 +95,19 @@ jobs:
           node-version: 24
           package-manager-cache: false
           registry-url: https://registry.npmjs.org
+
+      - name: Install npm 12
+        run: npm install --global npm@12.0.1
+
+      - name: Verify release tag
+        env:
+          RELEASE_TAG: ${{ needs.resolve-release.outputs.tag }}
+        run: |
+          expected_tag="v$(node -p 'require("./package.json").version')"
+          if [ "$RELEASE_TAG" != "$expected_tag" ]; then
+            echo "Release tag $RELEASE_TAG does not match package version $expected_tag" >&2
+            exit 1
+          fi
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
@@ -48,13 +129,27 @@ jobs:
           AISLOP_NO_UPDATE_NOTIFIER: "1"
           DO_NOT_TRACK: "1"
 
+      - name: Verify npm trusted publishing
+        shell: bash
+        run: |
+          set -euo pipefail
+          log_file="$(mktemp)"
+          trap 'rm -f "$log_file"' EXIT
+          npm publish --access public --dry-run --loglevel verbose 2>&1 | tee "$log_file"
+          if ! grep -Fq "Successfully retrieved and set token" "$log_file"; then
+            echo "npm trusted publishing token exchange failed" >&2
+            exit 1
+          fi
+
       - name: Publish to npm
+        if: ${{ github.event_name == 'release' || inputs.publish }}
         run: npm publish --access public
 
   publish-gpr:
     name: Publish to GitHub Packages
     runs-on: ubuntu-latest
-    needs: publish-npm
+    needs: [resolve-release, publish-npm]
+    if: ${{ github.event_name == 'release' || inputs.publish }}
     permissions:
       contents: read
       packages: write
@@ -62,7 +157,7 @@ jobs:
     steps:
       - uses: actions/checkout@v7
         with:
-          ref: ${{ github.event.release.tag_name }}
+          ref: ${{ needs.resolve-release.outputs.sha }}
 
       - uses: pnpm/action-setup@v6
 
@@ -90,17 +185,25 @@ jobs:
   move-major-tag:
     name: Move v1 Action tag to this release
     runs-on: ubuntu-latest
-    needs: publish-npm
-    if: ${{ !github.event.release.prerelease }}
+    needs: [resolve-release, publish-npm]
+    if: >-
+      ${{
+        (github.event_name == 'release' &&
+          needs.resolve-release.outputs.prerelease == 'false') ||
+        (github.event_name == 'workflow_dispatch' &&
+          inputs.publish &&
+          inputs.move-major-tag &&
+          needs.resolve-release.outputs.prerelease == 'false')
+      }}
     permissions:
       contents: write
 
     steps:
       - uses: actions/checkout@v7
         with:
-          ref: ${{ github.event.release.tag_name }}
+          ref: ${{ needs.resolve-release.outputs.sha }}
 
-      - name: Re-point v1 to ${{ github.event.release.tag_name }}
+      - name: Re-point v1 to ${{ needs.resolve-release.outputs.tag }}
         run: |
           git tag -f v1
           git push origin v1 --force

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -192,7 +192,7 @@ jobs:
           needs.resolve-release.outputs.prerelease == 'false') ||
         (github.event_name == 'workflow_dispatch' &&
           inputs.publish &&
-          inputs.move-major-tag &&
+          inputs['move-major-tag'] &&
           needs.resolve-release.outputs.prerelease == 'false')
       }}
     permissions:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -121,7 +121,7 @@ This applies to regex patterns, string literals, and diagnostic messages in all 
 
 - **Branch model**: branch from current `origin/develop`; open PRs to `develop` unless the task explicitly says otherwise.
 - **Main promotion**: `develop` -> `main` is a maintainer decision. Do not merge it just because checks are green.
-- **Releases**: automated via `.github/workflows/release.yml` on `v*` tags.
+- **Releases**: publishing a GitHub Release runs `.github/workflows/release.yml`; failed npm publishes can use its guarded manual recovery after promotion to `main`.
 - **CI**: Node 22 + 24 matrix, typecheck + build + test + self-scan.
 - All changes should pass: `pnpm typecheck && pnpm test && pnpm scan`.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -265,7 +265,9 @@ disabled. This performs the npm OIDC preflight without publishing. After that
 preflight succeeds, a maintainer may run it again with `publish` enabled.
 Enable `move-major-tag` only for a stable release. The recovery workflow accepts
 published GitHub Release tags and checks out their resolved commit, not a branch
-or arbitrary ref.
+or arbitrary ref. Manual recovery publishes disable npm provenance because the
+workflow run's default-branch ref differs from the release commit; normal
+GitHub Release publishes retain automatic trusted-publishing provenance.
 
 Version bumps follow [semver](https://semver.org/):
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -258,6 +258,15 @@ The npm package's trusted publisher must match these values exactly:
 - Workflow filename: `release.yml`
 - Allowed action: `npm publish`
 
+If npm publication fails after the GitHub Release is published, do not move or
+recreate the release tag. Promote the recovery workflow to the default branch,
+then run `Release` manually with the existing tag and leave both boolean inputs
+disabled. This performs the npm OIDC preflight without publishing. After that
+preflight succeeds, a maintainer may run it again with `publish` enabled.
+Enable `move-major-tag` only for a stable release. The recovery workflow accepts
+published GitHub Release tags and checks out their resolved commit, not a branch
+or arbitrary ref.
+
 Version bumps follow [semver](https://semver.org/):
 
 - **patch** -- bug fixes, false-positive fixes

--- a/tests/package-release-security.test.ts
+++ b/tests/package-release-security.test.ts
@@ -180,7 +180,7 @@ describe("package release security", () => {
 		expect(moveMajorCondition).toBe(
 			`${expressionStart} (github.event_name == 'release' && ${stableRelease}) || ` +
 				`(github.event_name == 'workflow_dispatch' && inputs.publish && ` +
-				`inputs.move-major-tag && ${stableRelease}) }}`,
+				`inputs['move-major-tag'] && ${stableRelease}) }}`,
 		);
 	});
 });

--- a/tests/package-release-security.test.ts
+++ b/tests/package-release-security.test.ts
@@ -10,22 +10,51 @@ const PackageManifestSchema = z.object({
 
 const WorkflowStepSchema = z.object({
 	env: z.record(z.string(), z.string()).optional(),
+	if: z.string().optional(),
 	name: z.string().optional(),
 	run: z.string().optional(),
+	shell: z.string().optional(),
 	uses: z.string().optional(),
 	with: z.record(z.string(), z.unknown()).optional(),
 });
 
 const WorkflowJobSchema = z.object({
+	if: z.string().optional(),
+	needs: z.union([z.string(), z.array(z.string())]).optional(),
+	outputs: z.record(z.string(), z.string()).optional(),
 	permissions: z.record(z.string(), z.string()),
 	steps: z.array(WorkflowStepSchema),
 });
 
 const ReleaseWorkflowSchema = z.object({
+	on: z.object({
+		release: z.object({
+			types: z.array(z.string()),
+		}),
+		workflow_dispatch: z.object({
+			inputs: z.object({
+				"move-major-tag": z.object({
+					default: z.boolean(),
+					required: z.boolean(),
+					type: z.literal("boolean"),
+				}),
+				publish: z.object({
+					default: z.boolean(),
+					required: z.boolean(),
+					type: z.literal("boolean"),
+				}),
+				tag: z.object({
+					required: z.boolean(),
+					type: z.literal("string"),
+				}),
+			}),
+		}),
+	}),
 	jobs: z.object({
 		"move-major-tag": WorkflowJobSchema,
 		"publish-gpr": WorkflowJobSchema,
 		"publish-npm": WorkflowJobSchema,
+		"resolve-release": WorkflowJobSchema,
 	}),
 	permissions: z.record(z.string(), z.string()),
 });
@@ -49,6 +78,7 @@ describe("package release security", () => {
 		const workflow = ReleaseWorkflowSchema.parse(parseYaml(workflowSource));
 		const npmJob = workflow.jobs["publish-npm"];
 		const setupNode = npmJob.steps.find((step) => step.uses?.startsWith("actions/setup-node@"));
+		const installNpm = npmJob.steps.find((step) => step.name === "Install npm 12");
 		const publish = npmJob.steps.find((step) => step.name === "Publish to npm");
 
 		expect(workflow.permissions).toEqual({ contents: "read" });
@@ -57,6 +87,7 @@ describe("package release security", () => {
 			"node-version": 24,
 			"package-manager-cache": false,
 		});
+		expect(installNpm?.run).toBe("npm install --global npm@12.0.1");
 		expect(publish?.run).toBe("npm publish --access public");
 		expect(publish?.env).toBeUndefined();
 		expect(workflowSource).not.toContain("secrets.NPM_TOKEN");
@@ -65,5 +96,91 @@ describe("package release security", () => {
 			packages: "write",
 		});
 		expect(workflow.jobs["move-major-tag"].permissions).toEqual({ contents: "write" });
+	});
+
+	it("resolves an existing GitHub release before executing its code", () => {
+		const workflow = ReleaseWorkflowSchema.parse(
+			parseYaml(fs.readFileSync(".github/workflows/release.yml", "utf8")),
+		);
+		const resolveJob = workflow.jobs["resolve-release"];
+		const resolveStep = resolveJob.steps.find((step) => step.name === "Resolve release");
+		const resolvedSha = "${{ needs.resolve-release.outputs.sha }}";
+		const checkoutRefs = [
+			workflow.jobs["publish-npm"],
+			workflow.jobs["publish-gpr"],
+			workflow.jobs["move-major-tag"],
+		].map((job) => job.steps.find((step) => step.uses?.startsWith("actions/checkout@"))?.with?.ref);
+
+		expect(resolveJob.permissions).toEqual({ contents: "read" });
+		expect(resolveJob.outputs).toEqual({
+			prerelease: "${{ steps.release.outputs.prerelease }}",
+			sha: "${{ steps.release.outputs.sha }}",
+			tag: "${{ steps.release.outputs.tag }}",
+		});
+		expect(resolveJob.steps.some((step) => step.uses?.startsWith("actions/checkout@"))).toBe(false);
+		expect(resolveStep?.env).toEqual({
+			GH_TOKEN: "${{ github.token }}",
+			RELEASE_TAG: "${{ github.event.release.tag_name || inputs.tag }}",
+		});
+		expect(resolveStep?.run).toContain(
+			'[[ "$RELEASE_TAG" =~ ^v[0-9]+\\.[0-9]+\\.[0-9]+(-[0-9A-Za-z.-]+)?$ ]]',
+		);
+		expect(resolveStep?.run).toContain(
+			'gh api "repos/$GITHUB_REPOSITORY/releases/tags/$RELEASE_TAG"',
+		);
+		expect(resolveStep?.run).toContain("[.draft, .prerelease, .published_at] | @tsv");
+		expect(resolveStep?.run).toContain('if [ "$draft" != "false" ]');
+		expect(resolveStep?.run).toContain('[ "$published_at" = "null" ]');
+		expect(resolveStep?.run).toContain(
+			'gh api "repos/$GITHUB_REPOSITORY/git/ref/tags/$RELEASE_TAG"',
+		);
+		expect(resolveStep?.run).toContain('if [ "$object_type" != "commit" ]');
+		expect(checkoutRefs).toEqual([resolvedSha, resolvedSha, resolvedSha]);
+		expect(workflow.jobs["publish-npm"].needs).toBe("resolve-release");
+		expect(workflow.jobs["publish-gpr"].needs).toEqual(["resolve-release", "publish-npm"]);
+		expect(workflow.jobs["move-major-tag"].needs).toEqual(["resolve-release", "publish-npm"]);
+	});
+
+	it("keeps manual recovery non-publishing unless explicitly enabled", () => {
+		const workflow = ReleaseWorkflowSchema.parse(
+			parseYaml(fs.readFileSync(".github/workflows/release.yml", "utf8")),
+		);
+		const npmJob = workflow.jobs["publish-npm"];
+		const verifyTag = npmJob.steps.find((step) => step.name === "Verify release tag");
+		const verifyTrust = npmJob.steps.find((step) => step.name === "Verify npm trusted publishing");
+		const publish = npmJob.steps.find((step) => step.name === "Publish to npm");
+		const publishCondition = "${{ github.event_name == 'release' || inputs.publish }}";
+		const stableRelease = "needs.resolve-release.outputs.prerelease == 'false'";
+		const expressionStart = "${{";
+		const moveMajorCondition = workflow.jobs["move-major-tag"].if?.replace(/\s+/g, " ").trim();
+
+		expect(workflow.on.release.types).toEqual(["published"]);
+		expect(workflow.on.workflow_dispatch.inputs.tag).toMatchObject({
+			required: true,
+			type: "string",
+		});
+		expect(workflow.on.workflow_dispatch.inputs["move-major-tag"]).toEqual({
+			default: false,
+			required: true,
+			type: "boolean",
+		});
+		expect(workflow.on.workflow_dispatch.inputs.publish).toEqual({
+			default: false,
+			required: true,
+			type: "boolean",
+		});
+		expect(verifyTag?.env).toEqual({ RELEASE_TAG: "${{ needs.resolve-release.outputs.tag }}" });
+		expect(verifyTag?.run).toContain('expected_tag="v$(node -p');
+		expect(verifyTag?.run).toContain('if [ "$RELEASE_TAG" != "$expected_tag" ]');
+		expect(verifyTrust?.shell).toBe("bash");
+		expect(verifyTrust?.run).toContain("npm publish --access public --dry-run --loglevel verbose");
+		expect(verifyTrust?.run).toContain('grep -Fq "Successfully retrieved and set token"');
+		expect(publish?.if).toBe(publishCondition);
+		expect(workflow.jobs["publish-gpr"].if).toBe(publishCondition);
+		expect(moveMajorCondition).toBe(
+			`${expressionStart} (github.event_name == 'release' && ${stableRelease}) || ` +
+				`(github.event_name == 'workflow_dispatch' && inputs.publish && ` +
+				`inputs.move-major-tag && ${stableRelease}) }}`,
+		);
 	});
 });

--- a/tests/package-release-security.test.ts
+++ b/tests/package-release-security.test.ts
@@ -149,6 +149,7 @@ describe("package release security", () => {
 		const verifyTag = npmJob.steps.find((step) => step.name === "Verify release tag");
 		const verifyTrust = npmJob.steps.find((step) => step.name === "Verify npm trusted publishing");
 		const publish = npmJob.steps.find((step) => step.name === "Publish to npm");
+		const recoveryPublish = npmJob.steps.find((step) => step.name === "Publish recovery to npm");
 		const publishCondition = "${{ github.event_name == 'release' || inputs.publish }}";
 		const stableRelease = "needs.resolve-release.outputs.prerelease == 'false'";
 		const expressionStart = "${{";
@@ -175,7 +176,12 @@ describe("package release security", () => {
 		expect(verifyTrust?.shell).toBe("bash");
 		expect(verifyTrust?.run).toContain("npm publish --access public --dry-run --loglevel verbose");
 		expect(verifyTrust?.run).toContain('grep -Fq "Successfully retrieved and set token"');
-		expect(publish?.if).toBe(publishCondition);
+		expect(publish?.if).toBe("${{ github.event_name == 'release' }}");
+		expect(recoveryPublish).toMatchObject({
+			env: { NPM_CONFIG_PROVENANCE: "false" },
+			if: "${{ github.event_name == 'workflow_dispatch' && inputs.publish }}",
+			run: "npm publish --access public",
+		});
 		expect(workflow.jobs["publish-gpr"].if).toBe(publishCondition);
 		expect(moveMajorCondition).toBe(
 			`${expressionStart} (github.event_name == 'release' && ${stableRelease}) || ` +


### PR DESCRIPTION
## Summary

Promote the guarded npm v12 release recovery from `develop` to the default branch so the manual preflight can be dispatched for the existing `v0.14.0` GitHub Release.

This promotion contains only:

- npm 12 Trusted Publisher preflight and explicit publish controls
- published-release resolution to an immutable commit SHA
- stable-only `v1` movement
- release-security tests and recovery documentation

## Validation

- PR #304 passed the full Linux/Windows Node 22/24 CI matrix
- both repository quality gates passed
- Aislop reported 100/100 with zero findings
- five read-only review lanes passed the exact source commit

No workflow has been dispatched and no package, tag, or release has been changed.
