### PR TITLE
fix(release): access hyphenated input safely

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -192,7 +192,7 @@ jobs:
           needs.resolve-release.outputs.prerelease == 'false') ||
         (github.event_name == 'workflow_dispatch' &&
           inputs.publish &&
-          inputs.move-major-tag &&
+          inputs['move-major-tag'] &&
           needs.resolve-release.outputs.prerelease == 'false')
       }}
     permissions:

--- a/tests/package-release-security.test.ts
+++ b/tests/package-release-security.test.ts
@@ -180,7 +180,7 @@ describe("package release security", () => {
 		expect(moveMajorCondition).toBe(
 			`${expressionStart} (github.event_name == 'release' && ${stableRelease}) || ` +
 				`(github.event_name == 'workflow_dispatch' && inputs.publish && ` +
-				`inputs.move-major-tag && ${stableRelease}) }}`,
+				`inputs['move-major-tag'] && ${stableRelease}) }}`,
 		);
 	});
 });


### PR DESCRIPTION
## Summary

- use bracket notation for the hyphenated `move-major-tag` workflow input
- update the exact release-security assertion to prevent regression

This addresses the two inline review comments on PR #305.

## Validation

- regression test failed before the workflow correction and passes afterward
- `pnpm vitest run tests/package-release-security.test.ts` (4 tests)
- `pnpm quality` (169 files, 1,558 tests, Aislop 100/100)
- five bounded read-only review lanes passed exact commit `0e615b8`

No workflow was dispatched and nothing was published.
