### PR TITLE
fix(release): preserve recovery provenance accuracy

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -142,8 +142,14 @@ jobs:
           fi
 
       - name: Publish to npm
-        if: ${{ github.event_name == 'release' || inputs.publish }}
+        if: ${{ github.event_name == 'release' }}
         run: npm publish --access public
+
+      - name: Publish recovery to npm
+        if: ${{ github.event_name == 'workflow_dispatch' && inputs.publish }}
+        run: npm publish --access public
+        env:
+          NPM_CONFIG_PROVENANCE: "false"
 
   publish-gpr:
     name: Publish to GitHub Packages

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -265,7 +265,9 @@ disabled. This performs the npm OIDC preflight without publishing. After that
 preflight succeeds, a maintainer may run it again with `publish` enabled.
 Enable `move-major-tag` only for a stable release. The recovery workflow accepts
 published GitHub Release tags and checks out their resolved commit, not a branch
-or arbitrary ref.
+or arbitrary ref. Manual recovery publishes disable npm provenance because the
+workflow run's default-branch ref differs from the release commit; normal
+GitHub Release publishes retain automatic trusted-publishing provenance.
 
 Version bumps follow [semver](https://semver.org/):
 

--- a/tests/package-release-security.test.ts
+++ b/tests/package-release-security.test.ts
@@ -149,6 +149,7 @@ describe("package release security", () => {
 		const verifyTag = npmJob.steps.find((step) => step.name === "Verify release tag");
 		const verifyTrust = npmJob.steps.find((step) => step.name === "Verify npm trusted publishing");
 		const publish = npmJob.steps.find((step) => step.name === "Publish to npm");
+		const recoveryPublish = npmJob.steps.find((step) => step.name === "Publish recovery to npm");
 		const publishCondition = "${{ github.event_name == 'release' || inputs.publish }}";
 		const stableRelease = "needs.resolve-release.outputs.prerelease == 'false'";
 		const expressionStart = "${{";
@@ -175,7 +176,12 @@ describe("package release security", () => {
 		expect(verifyTrust?.shell).toBe("bash");
 		expect(verifyTrust?.run).toContain("npm publish --access public --dry-run --loglevel verbose");
 		expect(verifyTrust?.run).toContain('grep -Fq "Successfully retrieved and set token"');
-		expect(publish?.if).toBe(publishCondition);
+		expect(publish?.if).toBe("${{ github.event_name == 'release' }}");
+		expect(recoveryPublish).toMatchObject({
+			env: { NPM_CONFIG_PROVENANCE: "false" },
+			if: "${{ github.event_name == 'workflow_dispatch' && inputs.publish }}",
+			run: "npm publish --access public",
+		});
 		expect(workflow.jobs["publish-gpr"].if).toBe(publishCondition);
 		expect(moveMajorCondition).toBe(
 			`${expressionStart} (github.event_name == 'release' && ${stableRelease}) || ` +


### PR DESCRIPTION
## Summary

- keep automatic npm provenance on normal GitHub Release publishing
- use a separate manual recovery publish step with `NPM_CONFIG_PROVENANCE=false`
- document why recovery cannot truthfully attest the historical release commit from a default-branch dispatch
- lock both mutually exclusive publish paths with release-security tests

This addresses the provenance review comment on PR #305.

## Validation

- regression test failed before the workflow correction and passes afterward
- `pnpm vitest run tests/package-release-security.test.ts` (4 tests)
- `pnpm quality` (169 files, 1,558 tests, Aislop 100/100)
- five bounded read-only review lanes passed exact commit `dfab9b3`

No workflow was dispatched and nothing was published.
