### PR TITLE
feat(cli): add value-triggered team pilot invitation

### DIFF
--- a/src/commands/scan-options.ts
+++ b/src/commands/scan-options.ts
@@ -1,0 +1,34 @@
+import type { ScanScopeMode } from "./scan-file-scope.js";
+
+export interface ScanOptions {
+	changes: boolean;
+	staged: boolean;
+	base?: string;
+	verbose: boolean;
+	json: boolean;
+	sarif?: boolean;
+	showHeader?: boolean;
+	printBrand?: boolean;
+	exclude?: string[];
+	include?: string[];
+	/** Used for telemetry to distinguish scan vs ci invocation */
+	command?: "scan" | "ci";
+}
+
+// SARIF and JSON are machine outputs: suppress all human chrome on stdout.
+export const isMachineOutput = (options: ScanOptions): boolean =>
+	Boolean(options.json) || Boolean(options.sarif);
+
+export const isHistoryComparableScan = (options: ScanOptions): boolean =>
+	!options.staged && !options.changes && options.command !== "ci";
+
+export const isFullProjectScan = (options: ScanOptions): boolean =>
+	isHistoryComparableScan(options) && !options.include?.length && !options.exclude?.length;
+
+export const resolveScanScopeMode = (options: ScanOptions): ScanScopeMode => {
+	if (options.staged) return { kind: "staged" };
+	if (options.changes) {
+		return options.base ? { kind: "changes", base: options.base } : { kind: "changes" };
+	}
+	return { kind: "full" };
+};

--- a/src/commands/scan-render.ts
+++ b/src/commands/scan-render.ts
@@ -114,6 +114,7 @@ interface BuildScanRenderInput {
 	verbose: boolean;
 	includeHeader?: boolean;
 	printBrand?: boolean;
+	showPilotInvitation?: boolean;
 }
 
 export const buildScanRender = (input: BuildScanRenderInput): string => {
@@ -147,9 +148,11 @@ export const buildScanRender = (input: BuildScanRenderInput): string => {
 	const cta =
 		input.printBrand === false
 			? ""
-			: errors + warnings > 0
+			: input.showPilotInvitation === true
 				? renderTeamCta(deps)
-				: renderStarCta(deps);
+				: errors + warnings === 0
+					? renderStarCta(deps)
+					: "";
 
 	if (input.diagnostics.length === 0 && input.score.score === 100) {
 		return `${header}${renderCleanRun(

--- a/src/commands/scan.ts
+++ b/src/commands/scan.ts
@@ -2,6 +2,7 @@ import fs from "node:fs";
 import path from "node:path";
 import { performance } from "node:perf_hooks";
 import { type AislopConfig, findConfigDir, RULES_FILE } from "../config/index.js";
+import { recordFullScanActivity } from "../engagement/full-scan-activity.js";
 import type { EngineConfig } from "../engines/types.js";
 import { renderDiagnostics } from "../output/terminal.js";
 import { calculateScore } from "../scoring/index.js";
@@ -13,47 +14,26 @@ import { renderHeader } from "../ui/header.js";
 import { log } from "../ui/logger.js";
 import { detectSourceLanguages, discoverProject } from "../utils/discover.js";
 import { baseRefExists } from "../utils/git.js";
-import { appendHistory } from "../utils/history.js";
 import { readAislopIgnorePatterns } from "../utils/source-files.js";
 import { applySuppressions } from "../utils/suppress.js";
 import { APP_VERSION } from "../version.js";
 import { renderCoverageNotice } from "./scan-coverage.js";
 import { runEnginesWithProgress } from "./scan-engine-runner.js";
 import { computeScanExitCode } from "./scan-exit-code.js";
-import { collectScanFileScope, deriveScanCoverage, type ScanScopeMode } from "./scan-file-scope.js";
+import { collectScanFileScope, deriveScanCoverage } from "./scan-file-scope.js";
+import {
+	isFullProjectScan,
+	isHistoryComparableScan,
+	isMachineOutput,
+	resolveScanScopeMode,
+	type ScanOptions,
+} from "./scan-options.js";
 import { buildScanRender } from "./scan-render.js";
 
 export { buildScanRender } from "./scan-render.js";
 
-interface ScanOptions {
-	changes: boolean;
-	staged: boolean;
-	base?: string;
-	verbose: boolean;
-	json: boolean;
-	sarif?: boolean;
-	showHeader?: boolean;
-	printBrand?: boolean;
-	exclude?: string[];
-	include?: string[];
-	/** Used for telemetry to distinguish scan vs ci invocation */
-	command?: "scan" | "ci";
-}
-
-// SARIF and JSON are machine outputs: suppress all human chrome on stdout.
-const isMachineOutput = (options: ScanOptions): boolean =>
-	Boolean(options.json) || Boolean(options.sarif);
-
 const renderScopeRow = (value: string): string =>
 	`${renderDisplayRows([{ label: "Scope", value }], { indent: 1 }).join("\n")}\n`;
-
-const resolveScanScopeMode = (options: ScanOptions): ScanScopeMode => {
-	if (options.staged) return { kind: "staged" };
-	if (options.changes) {
-		return options.base ? { kind: "changes", base: options.base } : { kind: "changes" };
-	}
-	return { kind: "full" };
-};
 
 export const scanCommand = async (
 	directory: string,
@@ -251,18 +231,20 @@ const runScanBody = async (
 		return completion;
 	}
 
-	// Only record full-project human scans: scoped (--staged/--changes) scores
-	// aren't comparable across runs, and CI runs would pollute local trends.
-	const isFullScopeScan = !options.staged && !options.changes && options.command !== "ci";
-	if (isFullScopeScan && !isCiEnv()) {
-		appendHistory({
-			directory: resolvedDir,
-			score: scoreResult.score,
-			errors: completion.errorCount,
-			warnings: completion.warningCount,
-			files: scoreFileCount,
-		});
-	}
+	const isLocalHistoryScan = isHistoryComparableScan(options) && !isCiEnv();
+	const showPilotInvitation = isLocalHistoryScan
+		? recordFullScanActivity(
+				{
+					directory: resolvedDir,
+					score: scoreResult.score,
+					errors: completion.errorCount,
+					warnings: completion.warningCount,
+					files: scoreFileCount,
+				},
+				isFullProjectScan(options) && options.printBrand !== false,
+				config.telemetry,
+			)
+		: false;
 
 	process.stdout.write(
 		buildScanRender({
@@ -277,6 +259,7 @@ const runScanBody = async (
 			verbose: options.verbose,
 			includeHeader: !printedHumanHeader && showHeader,
 			printBrand: options.printBrand,
+			showPilotInvitation,
 		}),
 	);
 

--- a/src/engagement/full-scan-activity.ts
+++ b/src/engagement/full-scan-activity.ts
@@ -1,0 +1,17 @@
+import { isTelemetryDisabled, type TelemetryConfig } from "../telemetry/client.js";
+import { type AppendHistoryInput, appendHistory, isHistoryDisabled } from "../utils/history.js";
+import { recordCompletedFullScan } from "./pilot-invitation.js";
+
+export const recordFullScanActivity = (
+	history: AppendHistoryInput,
+	allowPilotInvitation: boolean,
+	telemetryConfig: TelemetryConfig,
+): boolean => {
+	appendHistory(history);
+	return (
+		allowPilotInvitation &&
+		!isHistoryDisabled() &&
+		!isTelemetryDisabled(telemetryConfig) &&
+		recordCompletedFullScan()
+	);
+};

--- a/src/engagement/pilot-invitation.ts
+++ b/src/engagement/pilot-invitation.ts
@@ -1,0 +1,111 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+const STATE_BASENAME = "pilot_invitation.scans";
+const INVITATION_SCAN_THRESHOLD = 3;
+const PRIVATE_FILE_MODE = 0o600;
+const SCAN_RECORD = "1\n";
+const MAX_COUNTER_BYTES = 4096;
+
+const resolvePilotInvitationStatePath = (
+	homedir: string = os.homedir(),
+	env: NodeJS.ProcessEnv = process.env,
+): string => {
+	if (process.platform === "linux" && env.XDG_STATE_HOME) {
+		return path.join(env.XDG_STATE_HOME, "aislop", STATE_BASENAME);
+	}
+	return path.join(homedir, ".aislop", STATE_BASENAME);
+};
+
+const readCounter = (fileDescriptor: number, size: number): string => {
+	const buffer = Buffer.alloc(size);
+	if (size > 0) {
+		fs.readSync(fileDescriptor, buffer, 0, size, 0);
+	}
+	return buffer.toString("utf8");
+};
+
+const resolveNoFollowFlag = (): number | null => {
+	const value: unknown = Reflect.get(fs.constants, "O_NOFOLLOW");
+	return typeof value === "number" && value !== 0 ? value : null;
+};
+
+const ensureStateDirectory = (directory: string): boolean => {
+	try {
+		if (!fs.existsSync(directory)) {
+			fs.mkdirSync(directory, { recursive: true, mode: 0o700 });
+		}
+		const stat = fs.lstatSync(directory);
+		if (!stat.isDirectory()) return false;
+		if ((stat.mode & 0o777) !== 0o700) {
+			fs.chmodSync(directory, 0o700);
+		}
+		return true;
+	} catch {
+		return false;
+	}
+};
+
+const appendScan = (statePath: string, noFollowFlag: number | null): number | null => {
+	if (noFollowFlag === null) return null;
+	let fileDescriptor: number | undefined;
+	try {
+		if (!ensureStateDirectory(path.dirname(statePath))) return null;
+		const flags = fs.constants.O_APPEND | fs.constants.O_CREAT | fs.constants.O_RDWR | noFollowFlag;
+		fileDescriptor = fs.openSync(statePath, flags, PRIVATE_FILE_MODE);
+		const initialStat = fs.fstatSync(fileDescriptor);
+		if (!initialStat.isFile() || initialStat.size > MAX_COUNTER_BYTES) return null;
+		fs.fchmodSync(fileDescriptor, PRIVATE_FILE_MODE);
+
+		const existing = readCounter(fileDescriptor, initialStat.size);
+		if (!/^(1\n)*$/.test(existing)) return null;
+
+		fs.writeSync(fileDescriptor, SCAN_RECORD);
+		fs.fsyncSync(fileDescriptor);
+		const finalSize = fs.fstatSync(fileDescriptor).size;
+		return Math.floor(finalSize / Buffer.byteLength(SCAN_RECORD));
+	} catch {
+		return null;
+	} finally {
+		if (fileDescriptor !== undefined) {
+			fs.closeSync(fileDescriptor);
+		}
+	}
+};
+
+const claimInvitation = (statePath: string): boolean => {
+	const claimPath = `${statePath}.shown`;
+	try {
+		fs.writeFileSync(claimPath, "", {
+			flag: "wx",
+			mode: PRIVATE_FILE_MODE,
+		});
+		fs.chmodSync(claimPath, PRIVATE_FILE_MODE);
+		return true;
+	} catch {
+		return false;
+	}
+};
+
+const invitationAlreadyClaimed = (statePath: string): boolean => {
+	const claimPath = `${statePath}.shown`;
+	try {
+		return fs.lstatSync(claimPath).isFile();
+	} catch {
+		return false;
+	}
+};
+
+export const recordCompletedFullScan = (
+	statePath: string = resolvePilotInvitationStatePath(),
+	noFollowFlag: number | null = resolveNoFollowFlag(),
+): boolean => {
+	if (invitationAlreadyClaimed(statePath)) return false;
+	const completedFullScans = appendScan(statePath, noFollowFlag);
+	return (
+		completedFullScans !== null &&
+		completedFullScans >= INVITATION_SCAN_THRESHOLD &&
+		claimInvitation(statePath)
+	);
+};

--- a/src/ui/summary.ts
+++ b/src/ui/summary.ts
@@ -210,8 +210,8 @@ export const renderStarCta = (deps: SummaryDeps = {}): string => {
 
 export const renderTeamCta = (deps: SummaryDeps = {}): string => {
 	const t = deps.theme ?? defaultTheme;
-	const href = terminalLink("https://scanaislop.com");
-	return `\n ${style(t, "muted", `→ Make this your team's standard. Gate every PR free at ${href}`)}\n`;
+	const href = terminalLink("https://scanaislop.com/contact?intent=team-baseline");
+	return `\n ${style(t, "muted", `→ Using aislop with a team? Get a 14-day team baseline at ${href}`)}\n`;
 };
 
 export const renderCleanRun = (

--- a/src/utils/history.ts
+++ b/src/utils/history.ts
@@ -14,13 +14,13 @@ export interface HistoryRecord {
 	cliVersion: string;
 }
 
-const isHistoryDisabled = (env: NodeJS.ProcessEnv = process.env): boolean =>
+export const isHistoryDisabled = (env: NodeJS.ProcessEnv = process.env): boolean =>
 	env.AISLOP_NO_HISTORY === "1";
 
 const historyPath = (directory: string): string =>
 	path.join(path.resolve(directory), CONFIG_DIR, HISTORY_FILE);
 
-interface AppendHistoryInput {
+export interface AppendHistoryInput {
 	directory: string;
 	score: number;
 	errors: number;

--- a/tests/pilot-invitation.test.ts
+++ b/tests/pilot-invitation.test.ts
@@ -1,0 +1,271 @@
+import { spawn } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { pathToFileURL } from "node:url";
+import ts from "typescript";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { scanCommand } from "../src/commands/scan.js";
+import { DEFAULT_CONFIG } from "../src/config/defaults.js";
+import type { AislopConfig } from "../src/config/index.js";
+import { recordCompletedFullScan } from "../src/engagement/pilot-invitation.js";
+
+let projectDir: string;
+let stateHome: string;
+const noFollowFlag: unknown = Reflect.get(fs.constants, "O_NOFOLLOW");
+const secureNoFollowAvailable = typeof noFollowFlag === "number" && noFollowFlag !== 0;
+
+const config: AislopConfig = {
+	...DEFAULT_CONFIG,
+	engines: {
+		format: false,
+		lint: false,
+		"code-quality": false,
+		"ai-slop": false,
+		architecture: false,
+		security: false,
+	},
+	telemetry: { enabled: true },
+};
+
+const pilotStatePath = (): string =>
+	process.platform === "linux"
+		? path.join(stateHome, "aislop", "pilot_invitation.scans")
+		: path.join(stateHome, ".aislop", "pilot_invitation.scans");
+
+const runStateWorker = (moduleUrl: string, statePath: string): Promise<number | null> =>
+	new Promise((resolve, reject) => {
+		const source = `import { recordCompletedFullScan } from ${JSON.stringify(moduleUrl)}; process.exit(recordCompletedFullScan(${JSON.stringify(statePath)}) ? 0 : 2);`;
+		const child = spawn(process.execPath, ["--input-type=module", "--eval", source], {
+			stdio: "ignore",
+		});
+		child.once("error", reject);
+		child.once("close", resolve);
+	});
+
+const runHumanScan = async (
+	overrides: Partial<Parameters<typeof scanCommand>[2]> = {},
+	scanConfig: AislopConfig = config,
+): Promise<string> => {
+	vi.mocked(process.stdout.write).mockClear();
+	await scanCommand(projectDir, scanConfig, {
+		changes: false,
+		staged: false,
+		verbose: false,
+		json: false,
+		showHeader: false,
+		printBrand: true,
+		...overrides,
+	});
+	return vi
+		.mocked(process.stdout.write)
+		.mock.calls.map(([chunk]) => String(chunk))
+		.join("");
+};
+
+beforeEach(() => {
+	projectDir = fs.mkdtempSync(path.join(os.tmpdir(), "aislop-pilot-project-"));
+	stateHome = fs.mkdtempSync(path.join(os.tmpdir(), "aislop-pilot-state-"));
+	fs.mkdirSync(path.join(projectDir, "src"));
+	fs.writeFileSync(path.join(projectDir, "src", "app.ts"), "export const app = true;\n");
+	vi.stubEnv("HOME", stateHome);
+	vi.stubEnv("XDG_STATE_HOME", stateHome);
+	vi.stubEnv("CI", "");
+	vi.stubEnv("GITHUB_ACTIONS", "");
+	vi.stubEnv("AISLOP_TELEMETRY_DRY_RUN", "1");
+	vi.spyOn(process.stdout, "write").mockImplementation(() => true);
+});
+
+afterEach(() => {
+	vi.unstubAllEnvs();
+	vi.restoreAllMocks();
+	fs.rmSync(projectDir, { recursive: true, force: true });
+	fs.rmSync(stateHome, { recursive: true, force: true });
+});
+
+describe("pilot invitation", () => {
+	it.runIf(secureNoFollowAvailable)(
+		"appears once after the third completed full local scan",
+		async () => {
+			const first = await runHumanScan();
+			const second = await runHumanScan();
+			const third = await runHumanScan();
+			const fourth = await runHumanScan();
+
+			expect(first).not.toContain("intent=team-baseline");
+			expect(second).not.toContain("intent=team-baseline");
+			expect(third).toContain("intent=team-baseline");
+			expect(fourth).not.toContain("intent=team-baseline");
+		},
+	);
+
+	it("does not persist engagement state when local history is disabled", async () => {
+		vi.stubEnv("AISLOP_NO_HISTORY", "1");
+
+		const outputs = [await runHumanScan(), await runHumanScan(), await runHumanScan()];
+
+		expect(outputs.every((output) => !output.includes("intent=team-baseline"))).toBe(true);
+		expect(fs.existsSync(pilotStatePath())).toBe(false);
+	});
+
+	it.each(["AISLOP_NO_TELEMETRY", "DO_NOT_TRACK"])(
+		"does not persist engagement state when %s is set",
+		async (variable) => {
+			vi.stubEnv(variable, "1");
+
+			const outputs = [await runHumanScan(), await runHumanScan(), await runHumanScan()];
+
+			expect(outputs.every((output) => !output.includes("intent=team-baseline"))).toBe(true);
+			expect(fs.existsSync(pilotStatePath())).toBe(false);
+		},
+	);
+
+	it("does not persist engagement state when telemetry is disabled in config", async () => {
+		const telemetryDisabledConfig = { ...config, telemetry: { enabled: false } };
+
+		const outputs = [
+			await runHumanScan({}, telemetryDisabledConfig),
+			await runHumanScan({}, telemetryDisabledConfig),
+			await runHumanScan({}, telemetryDisabledConfig),
+		];
+
+		expect(outputs.every((output) => !output.includes("intent=team-baseline"))).toBe(true);
+		expect(fs.existsSync(pilotStatePath())).toBe(false);
+	});
+
+	it("does not count machine, CI, scoped, filtered, or unbranded scans", async () => {
+		await runHumanScan({ json: true });
+		await runHumanScan({ sarif: true });
+		vi.stubEnv("CI", "1");
+		await runHumanScan();
+		vi.stubEnv("CI", "");
+		await runHumanScan({ staged: true });
+		await runHumanScan({ include: ["src/**"] });
+		await runHumanScan({ exclude: ["src/**"] });
+		await runHumanScan({ printBrand: false });
+
+		expect(fs.existsSync(pilotStatePath())).toBe(false);
+		expect(await runHumanScan()).not.toContain("intent=team-baseline");
+	});
+
+	it("preserves history when an unbranded scan suppresses the invitation", async () => {
+		fs.mkdirSync(path.join(projectDir, ".aislop"));
+
+		await runHumanScan({ printBrand: false });
+
+		const history = fs.readFileSync(path.join(projectDir, ".aislop", "history.jsonl"), "utf8");
+		expect(history.trim().split("\n")).toHaveLength(1);
+		expect(fs.existsSync(pilotStatePath())).toBe(false);
+	});
+
+	it("preserves history when one-off filters suppress the invitation", async () => {
+		fs.mkdirSync(path.join(projectDir, ".aislop"));
+
+		await runHumanScan({ include: ["src/**"] });
+		await runHumanScan({ exclude: ["dist"] });
+
+		const history = fs.readFileSync(path.join(projectDir, ".aislop", "history.jsonl"), "utf8");
+		expect(history.trim().split("\n")).toHaveLength(2);
+		expect(fs.existsSync(pilotStatePath())).toBe(false);
+	});
+
+	it.runIf(secureNoFollowAvailable)(
+		"treats configured filters as the stable project baseline",
+		async () => {
+			const configuredScope = {
+				...config,
+				include: ["src/**"],
+				exclude: [...config.exclude, "generated"],
+			};
+
+			const first = await runHumanScan({}, configuredScope);
+			const second = await runHumanScan({}, configuredScope);
+			const third = await runHumanScan({}, configuredScope);
+
+			expect(first).not.toContain("intent=team-baseline");
+			expect(second).not.toContain("intent=team-baseline");
+			expect(third).toContain("intent=team-baseline");
+		},
+	);
+
+	it.runIf(secureNoFollowAvailable)("does not follow a symlink at the final state path", () => {
+		const statePath = path.join(stateHome, "direct", "pilot_invitation.json");
+		const protectedPath = path.join(stateHome, "protected.txt");
+		fs.mkdirSync(path.dirname(statePath), { recursive: true });
+		fs.writeFileSync(protectedPath, "unchanged");
+		fs.symlinkSync(protectedPath, statePath);
+
+		recordCompletedFullScan(statePath);
+
+		expect(fs.readFileSync(protectedPath, "utf8")).toBe("unchanged");
+	});
+
+	it("fails closed when the state directory is a symlink", () => {
+		const realDirectory = path.join(stateHome, "real-state");
+		const linkedDirectory = path.join(stateHome, "linked-state");
+		const statePath = path.join(linkedDirectory, "pilot_invitation.scans");
+		fs.mkdirSync(realDirectory);
+		fs.symlinkSync(realDirectory, linkedDirectory);
+
+		expect(recordCompletedFullScan(statePath)).toBe(false);
+		expect(fs.readdirSync(realDirectory)).toEqual([]);
+	});
+
+	it("fails closed when a no-follow file open is unavailable", () => {
+		const statePath = path.join(stateHome, "unsupported", "pilot_invitation.scans");
+
+		expect(recordCompletedFullScan(statePath, null)).toBe(false);
+		expect(fs.existsSync(statePath)).toBe(false);
+	});
+
+	it("fails closed before reading an oversized counter", () => {
+		const statePath = path.join(stateHome, "oversized", "pilot_invitation.scans");
+		fs.mkdirSync(path.dirname(statePath), { recursive: true });
+		fs.writeFileSync(statePath, "1\n".repeat(4097), { mode: 0o600 });
+
+		expect(recordCompletedFullScan(statePath)).toBe(false);
+		expect(fs.statSync(statePath).size).toBe(8194);
+	});
+
+	it.runIf(secureNoFollowAvailable)(
+		"stores state and the one-time claim with private permissions",
+		() => {
+			const statePath = path.join(stateHome, "private", "pilot_invitation.json");
+
+			expect(recordCompletedFullScan(statePath)).toBe(false);
+			expect(recordCompletedFullScan(statePath)).toBe(false);
+			expect(recordCompletedFullScan(statePath)).toBe(true);
+			expect(recordCompletedFullScan(statePath)).toBe(false);
+
+			expect(fs.statSync(statePath).mode & 0o777).toBe(0o600);
+			expect(fs.statSync(`${statePath}.shown`).mode & 0o777).toBe(0o600);
+		},
+	);
+
+	it.runIf(secureNoFollowAvailable)(
+		"counts three concurrent processes without duplicate invitations",
+		async () => {
+			const sourcePath = path.resolve("src/engagement/pilot-invitation.ts");
+			const modulePath = path.join(stateHome, "pilot-invitation.mjs");
+			const compiled = ts.transpileModule(fs.readFileSync(sourcePath, "utf8"), {
+				compilerOptions: {
+					module: ts.ModuleKind.ESNext,
+					target: ts.ScriptTarget.ES2022,
+				},
+			}).outputText;
+			fs.writeFileSync(modulePath, compiled);
+			const moduleUrl = pathToFileURL(modulePath).href;
+			const statePath = path.join(stateHome, "concurrent", "pilot_invitation.scans");
+
+			const exitCodes = await Promise.all([
+				runStateWorker(moduleUrl, statePath),
+				runStateWorker(moduleUrl, statePath),
+				runStateWorker(moduleUrl, statePath),
+			]);
+
+			expect(exitCodes.filter((code) => code === 0)).toHaveLength(1);
+			expect(exitCodes.filter((code) => code === 2)).toHaveLength(2);
+			expect(fs.readFileSync(statePath, "utf8").trim().split("\n")).toHaveLength(3);
+		},
+	);
+});

--- a/tests/ui/scan.render.test.ts
+++ b/tests/ui/scan.render.test.ts
@@ -41,6 +41,7 @@ describe("scan render", () => {
 				elapsedMs: 2300,
 				thresholds: { good: 85, ok: 65 },
 				verbose: false,
+				showPilotInvitation: true,
 			}),
 		);
 		expect(out).toContain("aislop");
@@ -57,7 +58,27 @@ describe("scan render", () => {
 		);
 		expect(out).toMatch(/Auto-fix\s+aislop fix\s+auto-fix 1 issue/);
 		expect(out).not.toContain("aislop fix --claude");
-		expect(out).toContain("Gate every PR free at https://scanaislop.com");
+		expect(out).toContain("14-day team baseline");
+		expect(out).toContain("https://scanaislop.com/contact?intent=team-baseline");
+	});
+
+	it("omits the pilot invitation when the scan is not eligible", () => {
+		const out = strip(
+			buildScanRender({
+				projectName: "my-app",
+				language: "typescript",
+				fileCount: 142,
+				results: [engineResult({ diagnostics: [diag()] })],
+				diagnostics: [diag()],
+				score: { score: 89, label: "Healthy" },
+				elapsedMs: 1000,
+				thresholds: { good: 85, ok: 65 },
+				verbose: false,
+				showPilotInvitation: false,
+			}),
+		);
+
+		expect(out).not.toContain("14-day team baseline");
 	});
 
 	it("renders clean-run one-liner when score is 100 and 0 issues", () => {

--- a/tests/ui/summary.test.ts
+++ b/tests/ui/summary.test.ts
@@ -239,6 +239,8 @@ describe("summary", () => {
 
 	it("renders the team CTA with a visible https URL", () => {
 		const out = strip(renderTeamCta(opts));
-		expect(out).toContain("Gate every PR free at https://scanaislop.com");
+		expect(out).toContain(
+			"Get a 14-day team baseline at https://scanaislop.com/contact?intent=team-baseline",
+		);
 	});
 });


### PR DESCRIPTION
## What changed

- Replaced the repeated team CTA after every issue scan with a one-time invitation after the third eligible scan.
- Limited eligibility to completed, scoreable, unscoped, local human scans of the configured project baseline.
- Excluded JSON, SARIF, CI, staged/changed scans, one-off `--include`/`--exclude` filters, unbranded runs, unscoreable runs, history-disabled runs, and telemetry opt-outs.
- Preserved normal local history for one-off filtered scans without advancing the engagement counter.
- Added private, bounded append-only local state with no-follow protection, `0600` files, `0700` directory permissions, and a single-winner concurrent claim.
- Kept clean-run star guidance and removed the generic issue-run sales prompt.

## Why

The CLI should invite a team conversation only after a user has received repeated value. This replaces a noisy generic prompt with a contextual, measurable conversion point while honoring existing privacy controls.

## User impact

On the third eligible scan, the CLI prints a single invitation to a 14-day team baseline. It is never repeated on that installation. There is no new email path, network request, or telemetry event.

## Validation

- `pnpm quality`
- 170 test files and 1,574 tests passed
- Aislop repository scan: 100, 0 errors, 0 warnings
- Built CLI: serial `false/false/true/false`
- Built CLI: three concurrent scans produced three records and one invitation
- Built CLI: history, filter, config-baseline, privacy opt-out, permissions, and fail-closed scenarios passed
- Exact commit reviewed across goal, QA, code quality, security/privacy, and repository-context lanes
