### PR TITLE
fix(release): restrict recovery publish to main

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -146,7 +146,12 @@ jobs:
         run: npm publish --access public
 
       - name: Publish recovery to npm
-        if: ${{ github.event_name == 'workflow_dispatch' && inputs.publish }}
+        if: >-
+          ${{
+            github.event_name == 'workflow_dispatch' &&
+            github.ref == format('refs/heads/{0}', github.event.repository.default_branch) &&
+            inputs.publish
+          }}
         run: npm publish --access public
         env:
           NPM_CONFIG_PROVENANCE: "false"
@@ -155,7 +160,13 @@ jobs:
     name: Publish to GitHub Packages
     runs-on: ubuntu-latest
     needs: [resolve-release, publish-npm]
-    if: ${{ github.event_name == 'release' || inputs.publish }}
+    if: >-
+      ${{
+        github.event_name == 'release' ||
+        (github.event_name == 'workflow_dispatch' &&
+          github.ref == format('refs/heads/{0}', github.event.repository.default_branch) &&
+          inputs.publish)
+      }}
     permissions:
       contents: read
       packages: write
@@ -197,6 +208,7 @@ jobs:
         (github.event_name == 'release' &&
           needs.resolve-release.outputs.prerelease == 'false') ||
         (github.event_name == 'workflow_dispatch' &&
+          github.ref == format('refs/heads/{0}', github.event.repository.default_branch) &&
           inputs.publish &&
           inputs['move-major-tag'] &&
           needs.resolve-release.outputs.prerelease == 'false')

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,6 +39,7 @@ jobs:
         id: release
         shell: bash
         env:
+          DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
           GH_TOKEN: ${{ github.token }}
           RELEASE_TAG: ${{ github.event.release.tag_name || inputs.tag }}
         run: |
@@ -66,6 +67,12 @@ jobs:
 
           if [ "$object_type" != "commit" ]; then
             echo "Release tag does not resolve to a commit" >&2
+            exit 1
+          fi
+
+          compare_status="$(gh api "repos/$GITHUB_REPOSITORY/compare/$object_sha...$DEFAULT_BRANCH" --jq '.status')"
+          if [ "$compare_status" != "ahead" ] && [ "$compare_status" != "identical" ]; then
+            echo "Release commit must be reachable from the default branch" >&2
             exit 1
           fi
 

--- a/tests/package-release-security.test.ts
+++ b/tests/package-release-security.test.ts
@@ -150,7 +150,10 @@ describe("package release security", () => {
 		const verifyTrust = npmJob.steps.find((step) => step.name === "Verify npm trusted publishing");
 		const publish = npmJob.steps.find((step) => step.name === "Publish to npm");
 		const recoveryPublish = npmJob.steps.find((step) => step.name === "Publish recovery to npm");
-		const publishCondition = "${{ github.event_name == 'release' || inputs.publish }}";
+		const defaultBranch =
+			"github.ref == format('refs/heads/{0}', github.event.repository.default_branch)";
+		const recoveryPublishCondition = recoveryPublish?.if?.replace(/\s+/g, " ").trim();
+		const publishGprCondition = workflow.jobs["publish-gpr"].if?.replace(/\s+/g, " ").trim();
 		const stableRelease = "needs.resolve-release.outputs.prerelease == 'false'";
 		const expressionStart = "${{";
 		const moveMajorCondition = workflow.jobs["move-major-tag"].if?.replace(/\s+/g, " ").trim();
@@ -179,13 +182,19 @@ describe("package release security", () => {
 		expect(publish?.if).toBe("${{ github.event_name == 'release' }}");
 		expect(recoveryPublish).toMatchObject({
 			env: { NPM_CONFIG_PROVENANCE: "false" },
-			if: "${{ github.event_name == 'workflow_dispatch' && inputs.publish }}",
 			run: "npm publish --access public",
 		});
-		expect(workflow.jobs["publish-gpr"].if).toBe(publishCondition);
+		expect(recoveryPublishCondition).toBe(
+			`${expressionStart} github.event_name == 'workflow_dispatch' && ${defaultBranch} && ` +
+				"inputs.publish }}",
+		);
+		expect(publishGprCondition).toBe(
+			`${expressionStart} github.event_name == 'release' || ` +
+				`(github.event_name == 'workflow_dispatch' && ${defaultBranch} && inputs.publish) }}`,
+		);
 		expect(moveMajorCondition).toBe(
 			`${expressionStart} (github.event_name == 'release' && ${stableRelease}) || ` +
-				`(github.event_name == 'workflow_dispatch' && inputs.publish && ` +
+				`(github.event_name == 'workflow_dispatch' && ${defaultBranch} && inputs.publish && ` +
 				`inputs['move-major-tag'] && ${stableRelease}) }}`,
 		);
 	});

--- a/tests/package-release-security.test.ts
+++ b/tests/package-release-security.test.ts
@@ -119,6 +119,7 @@ describe("package release security", () => {
 		});
 		expect(resolveJob.steps.some((step) => step.uses?.startsWith("actions/checkout@"))).toBe(false);
 		expect(resolveStep?.env).toEqual({
+			DEFAULT_BRANCH: "${{ github.event.repository.default_branch }}",
 			GH_TOKEN: "${{ github.token }}",
 			RELEASE_TAG: "${{ github.event.release.tag_name || inputs.tag }}",
 		});
@@ -135,6 +136,12 @@ describe("package release security", () => {
 			'gh api "repos/$GITHUB_REPOSITORY/git/ref/tags/$RELEASE_TAG"',
 		);
 		expect(resolveStep?.run).toContain('if [ "$object_type" != "commit" ]');
+		expect(resolveStep?.run).toContain(
+			'gh api "repos/$GITHUB_REPOSITORY/compare/$object_sha...$DEFAULT_BRANCH"',
+		);
+		expect(resolveStep?.run).toContain(
+			'if [ "$compare_status" != "ahead" ] && [ "$compare_status" != "identical" ]',
+		);
 		expect(checkoutRefs).toEqual([resolvedSha, resolvedSha, resolvedSha]);
 		expect(workflow.jobs["publish-npm"].needs).toBe("resolve-release");
 		expect(workflow.jobs["publish-gpr"].needs).toEqual(["resolve-release", "publish-npm"]);


### PR DESCRIPTION
## Summary

- require manual npm recovery publishing to run from the repository default branch
- apply the same guard to GitHub Packages publishing and v1 tag movement
- add exact workflow-security regression assertions

Addresses the delayed P2 review on #304: https://github.com/scanaislop/aislop/pull/304#discussion_r3640242439

## Validation

- `pnpm vitest run tests/package-release-security.test.ts` (4/4)
- `pnpm quality` (169 files, 1558 tests)
- Aislop 100/100, zero findings
- all scans used telemetry/history/update checks disabled

No workflow dispatch, package publication, or tag mutation was performed.