### PR TITLE
chore: promote release authentication fix to main

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -221,14 +221,16 @@ jobs:
           needs.resolve-release.outputs.prerelease == 'false')
       }}
     permissions:
-      contents: write
+      contents: read
 
     steps:
-      - uses: actions/checkout@v7
-        with:
-          ref: ${{ needs.resolve-release.outputs.sha }}
-
       - name: Re-point v1 to ${{ needs.resolve-release.outputs.tag }}
+        env:
+          GH_TOKEN: ${{ secrets.SYNC_BOT_PAT }}
+          RELEASE_SHA: ${{ needs.resolve-release.outputs.sha }}
         run: |
-          git tag -f v1
-          git push origin v1 --force
+          gh api \
+            --method PATCH \
+            "repos/$GITHUB_REPOSITORY/git/refs/tags/v1" \
+            --field "sha=$RELEASE_SHA" \
+            --field force=true

--- a/.github/workflows/sync-develop.yml
+++ b/.github/workflows/sync-develop.yml
@@ -16,11 +16,10 @@ jobs:
         with:
           fetch-depth: 0
           ref: develop
-          # SYNC_BOT_PAT is a fine-grained PAT with contents:write +
-          # pull-requests:write on this repo. Pushes via this token attribute
-          # to the PAT's user, which means downstream pull_request workflows
-          # (CI) actually fire — GITHUB_TOKEN can't because of GitHub's
-          # anti-loop guard.
+          # SYNC_BOT_PAT is a fine-grained PAT with contents:write,
+          # pull-requests:write, and workflows:write on this repo. Pushes via
+          # this token attribute to the PAT's user, so downstream pull_request
+          # workflows run; GITHUB_TOKEN cannot because of GitHub's anti-loop guard.
           token: ${{ secrets.SYNC_BOT_PAT }}
 
       - name: Configure git identity

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 **Catch the slop AI coding agents leave in your code.**
 
-[![npm version](https://img.shields.io/npm/v/aislop.svg)](https://www.npmjs.com/package/aislop) [![npm downloads](https://img.shields.io/npm/dm/aislop.svg)](https://www.npmjs.com/package/aislop) [![PyPI downloads](https://img.shields.io/pepy/dt/aislop.svg?label=PyPI%20downloads)](https://pypi.org/project/aislop/) [![Homebrew tap](https://img.shields.io/badge/Homebrew-scanaislop%2Ftap-2f855a.svg)](https://github.com/scanaislop/homebrew-tap) [![CI](https://github.com/scanaislop/aislop/actions/workflows/ci.yml/badge.svg)](https://github.com/scanaislop/aislop/actions/workflows/ci.yml) [![aislop score](https://badges.scanaislop.com/score/scanaislop/aislop.svg)](https://scanaislop.com/scanaislop/aislop) [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](https://opensource.org/licenses/MIT) [![Node >= 20](https://img.shields.io/badge/node-%3E%3D20-brightgreen.svg)](https://nodejs.org)
+[![npm version](https://img.shields.io/npm/v/aislop.svg)](https://www.npmjs.com/package/aislop) [![npm downloads](https://img.shields.io/npm/dm/aislop.svg)](https://www.npmjs.com/package/aislop) [![PyPI downloads](https://img.shields.io/pepy/dt/aislop.svg?label=PyPI%20downloads)](https://pypi.org/project/aislop/) [![Homebrew tap](https://img.shields.io/badge/Homebrew-scanaislop%2Ftap-2f855a.svg)](https://github.com/scanaislop/homebrew-tap) [![CI](https://github.com/scanaislop/aislop/actions/workflows/ci.yml/badge.svg)](https://github.com/scanaislop/aislop/actions/workflows/ci.yml) [![aislop score](https://badges.scanaislop.com/score/scanaislop/aislop.svg)](https://scanaislop.com/scanaislop/aislop) [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](https://opensource.org/licenses/MIT) [![Node >= 20](https://img.shields.io/badge/node-%3E%3D20-brightgreen.svg)](https://nodejs.org) [![Discord](https://img.shields.io/badge/Discord-Join-5865F2?logo=discord&logoColor=white)](https://discord.gg/Mzz4A6mfj6)
 
 The patterns Claude Code, Cursor, Codex, and OpenCode leave behind: narrative comments above self-explanatory code, swallowed exceptions, hidden fallbacks, `as any` casts, hallucinated imports, duplicated helpers, dead code, todo stubs, oversized functions. Tests pass. Lint passes. The code rots anyway.
 
@@ -479,7 +479,7 @@ aislop rules are shaped by public scans and benchmark-derived failure modes, not
 
 ## Community
 
-[Discussions](https://github.com/scanaislop/aislop/discussions) for questions, rule requests, and false-positive triage · [Issues](https://github.com/scanaislop/aislop/issues) for bugs
+[Discord](https://discord.gg/Mzz4A6mfj6) for community chat and support · [Discussions](https://github.com/scanaislop/aislop/discussions) for questions, rule requests, and false-positive triage · [Issues](https://github.com/scanaislop/aislop/issues) for bugs
 
 ## Contributing
 

--- a/tests/package-release-security.test.ts
+++ b/tests/package-release-security.test.ts
@@ -95,7 +95,7 @@ describe("package release security", () => {
 			contents: "read",
 			packages: "write",
 		});
-		expect(workflow.jobs["move-major-tag"].permissions).toEqual({ contents: "write" });
+		expect(workflow.jobs["move-major-tag"].permissions).toEqual({ contents: "read" });
 	});
 
 	it("resolves an existing GitHub release before executing its code", () => {
@@ -105,11 +105,9 @@ describe("package release security", () => {
 		const resolveJob = workflow.jobs["resolve-release"];
 		const resolveStep = resolveJob.steps.find((step) => step.name === "Resolve release");
 		const resolvedSha = "${{ needs.resolve-release.outputs.sha }}";
-		const checkoutRefs = [
-			workflow.jobs["publish-npm"],
-			workflow.jobs["publish-gpr"],
-			workflow.jobs["move-major-tag"],
-		].map((job) => job.steps.find((step) => step.uses?.startsWith("actions/checkout@"))?.with?.ref);
+		const checkoutRefs = [workflow.jobs["publish-npm"], workflow.jobs["publish-gpr"]].map(
+			(job) => job.steps.find((step) => step.uses?.startsWith("actions/checkout@"))?.with?.ref,
+		);
 
 		expect(resolveJob.permissions).toEqual({ contents: "read" });
 		expect(resolveJob.outputs).toEqual({
@@ -142,10 +140,32 @@ describe("package release security", () => {
 		expect(resolveStep?.run).toContain(
 			'if [ "$compare_status" != "ahead" ] && [ "$compare_status" != "identical" ]',
 		);
-		expect(checkoutRefs).toEqual([resolvedSha, resolvedSha, resolvedSha]);
+		expect(checkoutRefs).toEqual([resolvedSha, resolvedSha]);
 		expect(workflow.jobs["publish-npm"].needs).toBe("resolve-release");
 		expect(workflow.jobs["publish-gpr"].needs).toEqual(["resolve-release", "publish-npm"]);
 		expect(workflow.jobs["move-major-tag"].needs).toEqual(["resolve-release", "publish-npm"]);
+		expect(
+			workflow.jobs["move-major-tag"].steps.some((step) =>
+				step.uses?.startsWith("actions/checkout@"),
+			),
+		).toBe(false);
+	});
+
+	it("authenticates the v1 tag move with the workflow-capable bot token", () => {
+		const workflow = ReleaseWorkflowSchema.parse(
+			parseYaml(fs.readFileSync(".github/workflows/release.yml", "utf8")),
+		);
+		const moveMajorTag = workflow.jobs["move-major-tag"];
+		const updateRef = moveMajorTag.steps.find((step) => step.name?.startsWith("Re-point v1"));
+
+		expect(updateRef?.env).toEqual({
+			GH_TOKEN: "${{ secrets.SYNC_BOT_PAT }}",
+			RELEASE_SHA: "${{ needs.resolve-release.outputs.sha }}",
+		});
+		expect(updateRef?.run).toContain("--method PATCH");
+		expect(updateRef?.run).toContain('"repos/$GITHUB_REPOSITORY/git/refs/tags/v1"');
+		expect(updateRef?.run).toContain('--field "sha=$RELEASE_SHA"');
+		expect(updateRef?.run).toContain("--field force=true");
 	});
 
 	it("keeps manual recovery non-publishing unless explicitly enabled", () => {


### PR DESCRIPTION
## Summary

- promote the reviewed v1 tag-authentication fix and README Discord links from `develop`
- retain the existing npm OIDC release flow
- do not create a version, tag, GitHub release, or npm publication

## Validation

- source PR #311 completed 13/13 checks successfully
- exact release workflow tests passed
- no unresolved review threads or actionable reviewer comments