### PR TITLE
fix(cli): exit non-zero for invalid fix targets

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -219,13 +219,17 @@ for (const a of FIX_AGENT_FLAGS) fixProgram.option(`--${a.flag}`, a.help);
 
 fixProgram.action(async (directory = ".", _flags, command) => {
 	const flags = command.optsWithGlobals() as Record<string, boolean | undefined>;
-	await fixCommand(directory, loadConfig(directory), {
+	const { exitCode } = await fixCommand(directory, loadConfig(directory), {
 		verbose: Boolean(flags.verbose),
 		force: Boolean(flags.force),
 		safe: Boolean(flags.safe),
 		prompt: Boolean(flags.prompt),
 		agent: matchFixAgent(flags),
 	});
+	if (exitCode !== 0) {
+		await flushTelemetry();
+		process.exitCode = exitCode;
+	}
 });
 
 registerAgentCommand(program);

--- a/src/commands/fix.ts
+++ b/src/commands/fix.ts
@@ -91,20 +91,23 @@ export const fixCommand = async (
 	directory: string,
 	config: AislopConfig,
 	options: FixOptions = { verbose: false, showHeader: true },
-): Promise<void> => {
+): Promise<{ exitCode: number }> => {
 	const resolvedDir = path.resolve(directory);
+	const pathExists = fs.existsSync(resolvedDir);
 
-	if (!fs.existsSync(resolvedDir) || !fs.statSync(resolvedDir).isDirectory()) {
-		const msg = !fs.existsSync(resolvedDir)
+	if (!pathExists || !fs.statSync(resolvedDir).isDirectory()) {
+		const msg = !pathExists
 			? `Path does not exist: ${resolvedDir}`
 			: `Not a directory: ${resolvedDir}`;
-		log.error(msg);
-		return;
+		return withCommandLifecycle({ command: "fix", config: config.telemetry }, async () => {
+			log.error(msg);
+			return { exitCode: 1 };
+		});
 	}
 
 	const projectInfo = await discoverProject(resolvedDir);
 
-	await withCommandLifecycle(
+	return withCommandLifecycle(
 		{
 			command: "fix",
 			config: config.telemetry,

--- a/tests/cli-ergonomics.test.ts
+++ b/tests/cli-ergonomics.test.ts
@@ -1,5 +1,5 @@
 import { spawnSync } from "node:child_process";
-import { mkdtempSync, readFileSync } from "node:fs";
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { describe, expect, it } from "vitest";
@@ -101,6 +101,40 @@ describe("cli ergonomics", () => {
 		expect(result.stdout.trim()).toBe(PKG_VERSION);
 		expect(result.stderr).not.toContain("unknown option");
 	});
+
+	it("returns non-zero for missing and non-directory fix targets", () => {
+		const tempRoot = mkdtempSync(path.join(tmpdir(), "aislop-fix-target-"));
+		const missingPath = path.join(tempRoot, "missing");
+		const filePath = path.join(tempRoot, "not-a-directory");
+
+		try {
+			writeFileSync(filePath, "");
+			const missing = runCli(["fix", missingPath]);
+			expect(missing.status).toBe(1);
+			expect(`${missing.stdout}${missing.stderr}`).toContain(
+				`Path does not exist: ${missingPath}`,
+			);
+
+			const file = runCli(["fix", filePath]);
+			expect(file.status).toBe(1);
+			expect(`${file.stdout}${file.stderr}`).toContain(`Not a directory: ${filePath}`);
+		} finally {
+			rmSync(tempRoot, { recursive: true, force: true });
+		}
+	});
+
+	it("keeps a zero exit code for valid fix targets", () => {
+		const projectDir = mkdtempSync(path.join(tmpdir(), "aislop-fix-project-"));
+
+		try {
+			const result = runCli(["fix", projectDir, "--safe"]);
+			expect(result.status).toBe(0);
+			expect(`${result.stdout}${result.stderr}`).not.toContain("Path does not exist");
+			expect(`${result.stdout}${result.stderr}`).not.toContain("Not a directory");
+		} finally {
+			rmSync(projectDir, { recursive: true, force: true });
+		}
+	}, 30_000);
 
 	it("lists all commands and major flags", () => {
 		const result = runCli(["commands"]);

--- a/tests/telemetry/lifecycle.test.ts
+++ b/tests/telemetry/lifecycle.test.ts
@@ -54,6 +54,28 @@ describe("withCommandLifecycle", () => {
 		}
 	});
 
+	it("reports handled non-zero results as failed completions", async () => {
+		const cap = captureStderr();
+		try {
+			const result = await withCommandLifecycle({ command: "fix" }, async () => ({
+				exitCode: 1,
+			}));
+			expect(result.exitCode).toBe(1);
+			const events = cap.lines
+				.map((l) => l.match(/^\[telemetry\] (\{.*\})\n?$/))
+				.filter((m): m is RegExpMatchArray => !!m)
+				.map((m) => JSON.parse(m[1]));
+			const completed = events.find((e) => e.event === "cli_command_completed");
+			expect(completed?.properties).toMatchObject({
+				command: "fix",
+				exit_code: 1,
+			});
+			expect(completed?.properties.error_kind).toBeUndefined();
+		} finally {
+			cap.restore();
+		}
+	});
+
 	it("carries allowlisted agent properties and drops unsafe ones", async () => {
 		const cap = captureStderr();
 		try {


### PR DESCRIPTION
Fixes `aislop fix` returning a successful process status after rejecting an invalid target. Missing paths and existing non-directories still produce the same concise, path-specific error, but now exit with status 1; valid directories continue to exit 0.

The root cause was that `fixCommand` logged and returned without a command result, while the Commander action discarded the result on every path. Invalid-target validation also bypassed the normal command lifecycle, so aggregate completion telemetry never recorded the failure.

### Changes
- `src/commands/fix.ts`: return a command result, route invalid targets through `withCommandLifecycle`, and preserve the richer lifecycle metadata for valid projects.
- `src/cli.ts`: propagate a non-zero `fixCommand` result to `process.exitCode`, matching the existing `scan` and `ci` command pattern.
- `tests/cli-ergonomics.test.ts`: add platform-neutral subprocess regressions for a missing path, an existing file, and a valid directory, asserting both output and the actual process status.
- `tests/telemetry/lifecycle.test.ts`: verify handled non-zero results produce a completed lifecycle event with `exit_code: 1` and no synthetic exception kind.

### Red-to-green evidence
- Before the implementation, the new missing-path subprocess assertion failed with `expected 0 to be 1`.
- After the implementation, both focused suites pass: 23/23 tests.

### Validation
- `pnpm typecheck`
- `pnpm test` — 172 files, 1590 tests passed
- `pnpm scan` — 100/100 Healthy, no issues
- `git diff --check`

4 files changed, +71/-8.

AI assistance: Codex assisted with implementation and validation; the final diff and test output were reviewed before submission.

Closes #323.
