### PR TITLE
docs: refresh public project metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,12 @@ pipx install aislop                  # Python
 
 See [Installation](#installation) for every option.
 
+## Language support
+
+aislop supports TypeScript, JavaScript, Expo / React Native, Python, Go, Rust, Ruby, PHP, C#, and C/C++.
+
+Coverage includes formatting, linting, complexity, AI-slop detection, and security checks. Some checks use optional system tools; see [Installation](docs/installation.md) and the [rules reference](docs/rules.md) for details.
+
 ```bash
 aislop agent                 # repair with your coding agent (Codex/Claude/OpenCode)
 aislop fix                   # auto-fix the mechanical issues
@@ -456,11 +462,11 @@ Six deterministic engines run in parallel:
 
 | Engine | What it checks | How |
 |---|---|---|
-| **Formatting** | Code style consistency | Biome, ruff, gofmt, cargo fmt, rubocop, php-cs-fixer, clang-format (C/C++, requires `.clang-format`) |
-| **Linting** | Language-specific issues | oxlint, ruff, golangci-lint, clippy, expo-doctor, cppcheck + clang-tidy (C/C++; clang-tidy requires `compile_commands.json`) |
+| **Formatting** | Code style consistency | Biome, ruff, gofmt, cargo fmt, rubocop, php-cs-fixer, dotnet format, clang-format |
+| **Linting** | Language-specific issues | oxlint, ruff, golangci-lint, clippy, expo-doctor, Roslynator, JetBrains InspectCode, cppcheck, clang-tidy |
 | **Code Quality** | Complexity and dead code | Function/file size limits, deep nesting, unused files/deps (knip), AST-based unused-declaration removal |
 | **AI Slop** | AI-authored code patterns | Narrative comments, trivial comments, dead patterns, unused imports, `as any`, `console.log` leftovers, TODO stubs, generic names |
-| **Security** | Vulnerabilities and risky code | eval, innerHTML, SQL/shell injection, dependency audits (npm/pip/cargo/govulncheck) |
+| **Security** | Vulnerabilities and risky code | eval, innerHTML, SQL/shell injection, dependency audits for JavaScript, Python, Rust, Go, and .NET |
 | **Architecture** | Structural rules (opt-in) | Custom import bans, layering rules, required patterns |
 
 See the full [rules reference](docs/rules.md).

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -98,7 +98,15 @@ Some checks depend on tools already installed on your machine:
 - `.NET SDK`, `roslynator`, `jb` (C#)
 - `cppcheck`, `clang-format`, `clang-tidy` (C/C++)
 
-C# projects receive built-in text and complexity checks without optional lint tools. Install the .NET SDK for project-aware formatting and dependency checks. See the [rules reference](rules.md#c-linting-hybrid-jb--roslynator) for the optional lint setup.
+C# projects receive built-in text and complexity checks without optional lint tools. For project-aware formatting and dependency checks, install the .NET SDK and opt in for repositories you trust:
+
+```yaml
+lint:
+  csharp:
+    projectEvaluation: true
+```
+
+See the [rules reference](rules.md#c-linting-hybrid-jb--roslynator) for the optional lint setup.
 
 C/C++ tools are system installs that aislop shells out to - they are not bundled. Install them with your system package manager:
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -95,7 +95,10 @@ Some checks depend on tools already installed on your machine:
 - `cargo`, `clippy` (Rust)
 - `rubocop` (Ruby)
 - `phpcs`, `php-cs-fixer` (PHP)
+- `.NET SDK`, `roslynator`, `jb` (C#)
 - `cppcheck`, `clang-format`, `clang-tidy` (C/C++)
+
+C# projects receive built-in text and complexity checks without optional lint tools. Install the .NET SDK for project-aware formatting and dependency checks. See the [rules reference](rules.md#c-linting-hybrid-jb--roslynator) for the optional lint setup.
 
 C/C++ tools are system installs that aislop shells out to - they are not bundled. Install them with your system package manager:
 

--- a/package.json
+++ b/package.json
@@ -68,7 +68,10 @@
     "go",
     "rust",
     "ruby",
-    "php"
+    "php",
+    "csharp",
+    "dotnet",
+    "cpp"
   ],
   "author": {
     "name": "Kenny Olawuwo",


### PR DESCRIPTION
## Summary

- add a clear supported-language section to the README
- include C# in the public engine and installation guidance
- add C#, .NET, and C++ package search keywords

## Why

The public documentation and package metadata should match the 10 language targets already supported by aislop.

## Validation

- typecheck passed
- 198 test files and 2,032 tests passed
- dependency audits found no known vulnerabilities
- npm package publication dry-run passed
- Aislop scan scored 100/100 with zero findings
- the complete diff was checked for personal data, credentials, local paths, and private operational detail