### PR TITLE
fix(build): clean tsdown warnings

### DIFF
--- a/src/commands/fix-pipeline.ts
+++ b/src/commands/fix-pipeline.ts
@@ -20,7 +20,7 @@ import {
 	removeUnusedDeclarations,
 } from "../engines/code-quality/unused-removal.js";
 import { runExpoDoctor } from "../engines/lint/expo-doctor.js";
-import { fixRubyLint } from "../engines/lint/generic.js";
+import { fixRubyLint, runGenericLinter } from "../engines/lint/generic.js";
 import { fixOxlint, runOxlint } from "../engines/lint/oxlint.js";
 import { fixRuffLint, fixRuffLintForce, runRuffLint } from "../engines/lint/ruff.js";
 import { runDependencyAudit } from "../engines/security/audit.js";
@@ -137,10 +137,7 @@ export const runLintSteps = async (deps: PipelineDeps): Promise<void> => {
 	if (deps.projectInfo.languages.includes("ruby") && deps.projectInfo.installedTools.rubocop) {
 		await deps.runStep(
 			"Lint fixes (ruby)",
-			() =>
-				import("../engines/lint/generic.js").then((mod) =>
-					mod.runGenericLinter(deps.context, "ruby"),
-				),
+			() => runGenericLinter(deps.context, "ruby"),
 			() => fixRubyLint(deps.resolvedDir),
 		);
 	} else if (deps.projectInfo.languages.includes("ruby")) {

--- a/src/engines/lint/index.ts
+++ b/src/engines/lint/index.ts
@@ -2,11 +2,13 @@ import type { Diagnostic, Engine, EngineContext, EngineResult } from "../types.j
 import { runClangTidy } from "./clang-tidy.js";
 import { resolveCppLintConfig, runCppcheck } from "./cppcheck.js";
 import { runDotnetLint } from "./dotnet.js";
+import { runExpoDoctor } from "./expo-doctor.js";
 import { runGenericLinter } from "./generic.js";
 import { runGolangciLint } from "./golangci.js";
 import { resolveCsharpLintConfig, runJbLint } from "./jb.js";
 import { runOxlint } from "./oxlint.js";
 import { runRuffLint } from "./ruff.js";
+import { runTypecheck } from "./typecheck.js";
 
 // jb reports a Roslyn finding as "jb/<id>" and roslynator as "dotnet/<id>"; when
 // a project both references one of aislop's bundled analyzers AND jb runs it, the
@@ -74,13 +76,13 @@ export const lintEngine: Engine = {
 		if (languages.includes("typescript") || languages.includes("javascript")) {
 			promises.push(runOxlint(context));
 			if (context.config.lint.typecheck) {
-				promises.push(import("./typecheck.js").then((mod) => mod.runTypecheck(context)));
+				promises.push(runTypecheck(context));
 			}
 		}
 
 		if (context.frameworks.includes("expo") && context.config.lint.expoDoctor) {
 			// Expo Doctor may evaluate project config, so only run it when explicitly enabled.
-			promises.push(import("./expo-doctor.js").then((mod) => mod.runExpoDoctor(context)));
+			promises.push(runExpoDoctor(context));
 		}
 
 		if (languages.includes("python") && installedTools.ruff) {

--- a/tests/engines/lint-expo-opt-in.test.ts
+++ b/tests/engines/lint-expo-opt-in.test.ts
@@ -3,7 +3,9 @@ import { DEFAULT_CONFIG } from "../../src/config/defaults.js";
 import { lintEngine } from "../../src/engines/lint/index.js";
 import type { EngineContext } from "../../src/engines/types.js";
 
-const runExpoDoctorMock = vi.fn(async () => []);
+const { runExpoDoctorMock } = vi.hoisted(() => ({
+	runExpoDoctorMock: vi.fn(async () => []),
+}));
 
 vi.mock("../../src/engines/lint/expo-doctor.js", () => ({
 	runExpoDoctor: runExpoDoctorMock,

--- a/tsdown.config.ts
+++ b/tsdown.config.ts
@@ -10,7 +10,9 @@ export default defineConfig([
 		entry: {
 			cli: "./src/cli.ts",
 		},
-		external: ["oxlint", "knip", "knip/session", "@biomejs/biome", "typescript"],
+		deps: {
+			neverBundle: ["oxlint", "knip", "knip/session", "@biomejs/biome", "typescript"],
+		},
 		dts: true,
 		target: "node18",
 		platform: "node",
@@ -29,7 +31,9 @@ export default defineConfig([
 			"adapters/sveltekit": "./src/framework-adapters/sveltekit.ts",
 			"adapters/vite": "./src/framework-adapters/vite.ts",
 		},
-		external: ["oxlint", "knip", "knip/session", "@biomejs/biome", "typescript"],
+		deps: {
+			neverBundle: ["oxlint", "knip", "knip/session", "@biomejs/biome", "typescript"],
+		},
 		dts: true,
 		target: "node18",
 		platform: "node",
@@ -42,7 +46,9 @@ export default defineConfig([
 		entry: {
 			mcp: "./src/mcp.ts",
 		},
-		external: ["oxlint", "knip", "knip/session", "@biomejs/biome", "typescript"],
+		deps: {
+			neverBundle: ["oxlint", "knip", "knip/session", "@biomejs/biome", "typescript"],
+		},
 		dts: false,
 		target: "node18",
 		platform: "node",


### PR DESCRIPTION
## Summary

- migrate the deprecated tsdown `external` option to `deps.neverBundle`
- replace dynamic imports that Rolldown proved could not create separate chunks
- update the Expo Doctor opt-in test fixture for the now-static import

## Why

The v0.14.1 release build succeeded, but it emitted three tsdown deprecation warnings and repeated `INEFFECTIVE_DYNAMIC_IMPORT` diagnostics. The affected modules were already statically reachable in the same bundle graphs, so the dynamic imports added no code-splitting benefit.

Rolldown's plugin timing notices remain enabled because they are build-performance diagnostics, not failures.

## Validation

- `pnpm build` (zero deprecated-option or ineffective-import diagnostics)
- `pnpm typecheck`
- `pnpm exec vitest run` (198 files, 2,032 tests)
- `pnpm audit --audit-level=low` and `pnpm audit --prod` (zero known vulnerabilities)
- `npm audit signatures` (458 verified registry signatures, 123 verified attestations)
- source-built self-scan: 100/100, 518 files, zero findings
- published `npx --yes aislop@0.14.1` scan: 100/100, 518 files, zero findings
