### PR TITLE
test: give two Windows-heavy CLI test suites CI headroom

### DIFF
--- a/tests/cli-ergonomics.test.ts
+++ b/tests/cli-ergonomics.test.ts
@@ -64,7 +64,10 @@ const PUBLIC_HELP_COMMANDS: string[][] = [
 	["version", "--help"],
 	["commands", "--help"],
 ];
-const PUBLIC_HELP_TIMEOUT_MS = process.platform === "win32" ? 120_000 : 60_000;
+// 44 sequential CLI spawns; windows-latest Node 22 runners have been observed
+// taking ~1.5s per spawn (65s total), so lower ceilings left no headroom for
+// runner variance.
+const PUBLIC_HELP_TIMEOUT_MS = process.platform === "win32" ? 180_000 : 60_000;
 
 describe("cli ergonomics", () => {
 	it("uses the installed command in top-level help and keeps npx for one-off latest runs", () => {

--- a/tests/pilot-invitation.test.ts
+++ b/tests/pilot-invitation.test.ts
@@ -146,7 +146,9 @@ describe("pilot invitation", () => {
 
 		expect(fs.existsSync(pilotStatePath())).toBe(false);
 		expect(await runHumanScan()).not.toContain("intent=team-baseline");
-	});
+		// 8 sequential real scan invocations; a loaded Windows CI runner has been
+		// observed blowing past the 30s suite default on this test alone.
+	}, 120_000);
 
 	it("preserves history when an unbranded scan suppresses the invitation", async () => {
 		fs.mkdirSync(path.join(projectDir, ".aislop"));


### PR DESCRIPTION
Two tests chain many real CLI spawns and time out on loaded Windows runners while every other test stays green:

- The pilot-invitation test "does not count machine, CI, scoped, filtered, or unbranded scans" runs 8 sequential scan invocations and has been observed blowing past the 30s suite default on a busy self-hosted Windows runner. It gets a per-test timeout of 120s.
- The cli-ergonomics public-help matrix spawns the CLI 44 times sequentially; windows-latest Node 22 runners have been measured at ~1.5s per spawn (65s total), so the current 120s win32 ceiling leaves little headroom for runner variance. Raised to 180s.

Timeout-only change; no assertions are weakened. Both timeouts carry comments recording the measurements so future readers know the numbers are empirical rather than arbitrary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
